### PR TITLE
Constrained pool to ensure LUNC can never have more then 2T supply

### DIFF
--- a/x/market/keeper/swap.go
+++ b/x/market/keeper/swap.go
@@ -120,7 +120,7 @@ func (k Keeper) ComputeSwap(ctx sdk.Context, offerCoin sdk.Coin, askDenom string
 		askPool = ConstrainedPool{Pool: terraPool}
 
 	}
-	// Simply hack to ensure that swaps into Luna pool can not happen if it will exceed 2T supply
+	// Simply hack to ensure that swaps into askPool can not happen if it will exceed MaxSize
 	if (askPool.MaxSize != sdk.Dec{} && askPool.Pool.Add(retDecCoin.Amount).GT(askPool.MaxSize)) {
 		return sdk.DecCoin{}, sdk.Dec{}, sdkerrors.Wrap(types.ErrExceedMaxDelta, retDecCoin.Denom)
 	}

--- a/x/market/keeper/swap.go
+++ b/x/market/keeper/swap.go
@@ -9,6 +9,11 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
+type ConstrainedPool struct {
+	Pool    sdk.Dec
+	MaxSize sdk.Dec
+}
+
 // ApplySwapToPool updates each pool with offerCoin and askCoin taken from swap operation,
 // OfferPool = OfferPool + offerAmt (Fills the swap pool with offerAmt)
 // AskPool = AskPool - askAmt       (Uses askAmt from the swap pool)
@@ -103,22 +108,27 @@ func (k Keeper) ComputeSwap(ctx sdk.Context, offerCoin sdk.Coin, askDenom string
 	terraPool := basePool.Add(terraPoolDelta)
 	lunaPool := cp.Quo(terraPool)
 
-	var offerPool sdk.Dec // base denom(usdr) unit
-	var askPool sdk.Dec   // base denom(usdr) unit
+	var offerPool sdk.Dec       // base denom(usdr) unit
+	var askPool ConstrainedPool // base denom(usdr) unit
 	if offerCoin.Denom != core.MicroLunaDenom {
 		// Terra->Luna swap
 		offerPool = terraPool
-		askPool = lunaPool
+		askPool = ConstrainedPool{Pool: lunaPool, MaxSize: sdk.NewDec(2000000000000)}
 	} else {
 		// Luna->Terra swap
 		offerPool = lunaPool
-		askPool = terraPool
+		askPool = ConstrainedPool{Pool: terraPool}
+
+	}
+	// Simply hack to ensure that swaps into Luna pool can not happen if it will exceed 2T supply
+	if (askPool.MaxSize != sdk.Dec{} && askPool.Pool.Add(retDecCoin.Amount).GT(askPool.MaxSize)) {
+		return sdk.DecCoin{}, sdk.Dec{}, sdkerrors.Wrap(types.ErrExceedMaxDelta, retDecCoin.Denom)
 	}
 
 	// Get cp(constant-product) based swap amount
 	// askBaseAmount = askPool - cp / (offerPool + offerBaseAmount)
 	// askBaseAmount is base denom(usdr) unit
-	askBaseAmount := askPool.Sub(cp.Quo(offerPool.Add(baseOfferDecCoin.Amount)))
+	askBaseAmount := askPool.Pool.Sub(cp.Quo(offerPool.Add(baseOfferDecCoin.Amount)))
 
 	// Both baseOffer and baseAsk are usdr units, so spread can be calculated by
 	// spread = (baseOfferAmt - baseAskAmt) / baseOfferAmt

--- a/x/market/keeper/swap_test.go
+++ b/x/market/keeper/swap_test.go
@@ -108,3 +108,17 @@ func TestIlliquidTobinTaxListParams(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tobinTax.Mul(illiquidFactor), spread)
 }
+
+func TestConstrainedPool(t *testing.T) {
+	input := CreateTestInput(t)
+
+	lunaPriceInSDR := sdk.NewDecWithPrec(17, 1)
+	input.OracleKeeper.SetLunaExchangeRate(input.Ctx, core.MicroSDRDenom, lunaPriceInSDR)
+	input.OracleKeeper.SetLunaExchangeRate(input.Ctx, core.MicroLunaDenom, lunaPriceInSDR)
+
+	offerCoin := sdk.NewCoin(core.MicroSDRDenom, sdk.NewInt(2000000000001))
+
+	_, _, err := input.MarketKeeper.ComputeSwap(input.Ctx, offerCoin, core.MicroLunaDenom)
+
+	require.EqualError(t, err, "uluna: exceeded maximum ask coin delta")
+}

--- a/x/market/types/errors.go
+++ b/x/market/types/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrRecursiveSwap    = sdkerrors.Register(ModuleName, 2, "recursive swap")
 	ErrNoEffectivePrice = sdkerrors.Register(ModuleName, 3, "no price registered with oracle")
 	ErrZeroSwapCoin     = sdkerrors.Register(ModuleName, 4, "zero swap coin")
+	ErrExceedMaxDelta   = sdkerrors.Register(ModuleName, 5, "exceeded maximum ask coin delta")
 )


### PR DESCRIPTION
## Summary of changes

This is some old code I wrote back in my first PR for TFL. The idea is to add a 2T hardcap, which should probably be set to 10B based on 3568,  that will ensure we can never get into a situation of minting  infinite supply  when we eventually re-enable swapping from USTC => LUNC.

## Report of required housekeeping

- [x] Github issue OR spec proposal link
- [x] Wrote tests
- [x] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [x] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [x] Added appropriate labels to PR
- [x] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [x] Confirm added tests are consistent with the intended behavior of changes
- [x] Ensure all tests pass
