### PR TITLE
refactor: add number of validators and chain id as testnet parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ localnet-start: localnet-stop build-linux
 		-v /etc/group:/etc/group:ro \
 		-v /etc/passwd:/etc/passwd:ro \
 		-v /etc/shadow:/etc/shadow:ro \
-		terramoney/terrad-env testnet --chain-id ${TESTNET_CHAINID} --v ${TESTNET_NVAL} -o . --starting-ip-address 192.168.10.2 --keyring-backend=test ; fi
+		classic-terra/terrad-env testnet --chain-id ${TESTNET_CHAINID} --v ${TESTNET_NVAL} -o . --starting-ip-address 192.168.10.2 --keyring-backend=test ; fi
 	docker-compose up -d
 
 localnet-start-upgrade: localnet-upgrade-stop build-linux

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ HTTPS_GIT := https://github.com/classic-terra/core.git
 DOCKER := $(shell which docker)
 DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bufbuild/buf
 
+#TESTNET PARAMETERS
+TESTNET_NVAL := $(if $(TESTNET_NVAL),$(TESTNET_NVAL),4)
+TESTNET_CHAINID := $(if $(TESTNET_CHAINID),$(TESTNET_CHAINID),localnet-1)
+
 ifneq ($(OS),Windows_NT)
   UNAME_S = $(shell uname -s)
 endif
@@ -249,7 +253,7 @@ localnet-start: localnet-stop build-linux
 		-v /etc/group:/etc/group:ro \
 		-v /etc/passwd:/etc/passwd:ro \
 		-v /etc/shadow:/etc/shadow:ro \
-		classic-terra/terrad-env testnet --v 4 -o . --starting-ip-address 192.168.10.2 --keyring-backend=test ; fi
+		terramoney/terrad-env testnet --chain-id ${TESTNET_CHAINID} --v ${TESTNET_NVAL} -o . --starting-ip-address 192.168.10.2 --keyring-backend=test ; fi
 	docker-compose up -d
 
 localnet-start-upgrade: localnet-upgrade-stop build-linux

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
 
   terradnode4:
     container_name: terradnode4
-    image: "terramoney/terrad-env"
+    image: classic-terra/terrad-env
     environment:
       - ID=4
       - LOG=$${LOG:-terrad.log}
@@ -82,7 +82,7 @@ services:
 
   terradnode5:
     container_name: terradnode5
-    image: "terramoney/terrad-env"
+    image: classic-terra/terrad-env
     environment:
       - ID=5
       - LOG=$${LOG:-terrad.log}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,36 @@ services:
       localnet:
         ipv4_address: 192.168.10.5
 
+  terradnode4:
+    container_name: terradnode4
+    image: "terramoney/terrad-env"
+    environment:
+      - ID=4
+      - LOG=$${LOG:-terrad.log}
+    ports:
+      - "9094:9090"
+      - "26665-26666:26656-26657"
+    volumes:
+      - ./build:/terrad:Z
+    networks:
+      localnet:
+        ipv4_address: 192.168.10.6
+
+  terradnode5:
+    container_name: terradnode5
+    image: "terramoney/terrad-env"
+    environment:
+      - ID=5
+      - LOG=$${LOG:-terrad.log}
+    ports:
+      - "9095:9090"
+      - "26667-26668:26656-26657"
+    volumes:
+      - ./build:/terrad:Z
+    networks:
+      localnet:
+        ipv4_address: 192.168.10.7
+
 networks:
   localnet:
     driver: bridge


### PR DESCRIPTION
Parametrized the local testnet tooling. A local testnet with 2 validators and with chain id "testnet-1" can be spun up using the following commands:

`TESTNET_NVAL=2 TESTNET_CHAINID=testnet-1 make localnet-start`

Default values are `4` and `chain-<rand(6)>`

I also increased the maximum number of possible validators in the localnet to 6, because the min. number of validators on columbus-5 would be 5 (due to 20% voting power cap).