### PR TITLE
feat: panic at columbus genesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (ante) [#103](https://github.com/classic-terra/core/pull/103) Add burn tax split logic
 * (ante) [#107](https://github.com/classic-terra/core/pull/107) Burn Tax Whitelist
 * (build) [#118](https://github.com/classic-terra/core/pull/118) localnet for Apple Silicon
+* (app) [#128](https://github.com/classic-terra/core/pull/128) Panic at InitChainer for the Columbus mainnet
 
 ### Improvements
 * (build) [#93](https://github.com/classic-terra/core/pull/93) Use golang 1.18 and fix ad-hoc security vulnerabilities

--- a/app/app.go
+++ b/app/app.go
@@ -629,7 +629,7 @@ func (app *TerraApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) a
 	}
 
 	// trigger SetModuleVersionMap in upgrade keeper at the VersionMapEnableHeight
-	if ctx.BlockHeight() == core.VersionMapEnableHeight {
+	if ctx.ChainID() == core.ColumbusChainID && ctx.BlockHeight() == core.VersionMapEnableHeight {
 		app.UpgradeKeeper.SetModuleVersionMap(ctx, app.mm.GetVersionMap())
 	}
 

--- a/app/app.go
+++ b/app/app.go
@@ -647,6 +647,9 @@ func (app *TerraApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abc
 	if err := tmjson.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
 		panic(err)
 	}
+	if ctx.ChainID() == core.ColumbusChainID {
+		panic("Must use v1.0.x for importing the columbus genesis (https://github.com/classic-terra/core/releases/)")
+	}
 	app.UpgradeKeeper.SetModuleVersionMap(ctx, app.mm.GetVersionMap())
 	return app.mm.InitGenesis(ctx, app.appCodec, genesisState)
 }


### PR DESCRIPTION
## Summary of changes
This is a complementary feature for operators who are trying to use version > v1.0 for importing the genesis of Columbus mainnet.

For example, genesis importing is essential if someone wants to use PebbleDB implementation, in which case a new DB must be built based on v1.0.x

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
