### PR TITLE
fix: upgrade test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (build) [#97](https://github.com/classic-terra/core/pull/97) Change module path to classic-terra/core
 * (build) [#102](https://github.com/classic-terra/core/pull/102) Snyk secops patches
 * (build) [#105](https://github.com/classic-terra/core/pull/105) Update docker assets
+* [#102](https://github.com/classic-terra/core/pull/112) Upgrade SDK proto to v0.7
 
 ### Bug Fixes
 * (auth/client) [#106](https://github.com/classic-terra/core/pull/106) fix ungraceful error on failed client tax query

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -36,11 +36,11 @@ then
     GOBIN="$ROOT/_build/new" go install -mod=readonly ./...
 fi
 
-# spin up mytestnet
+# run old node
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    screen -L -dmS node1 bash scripts/run-node.sh _build/new/terrad $DENOM
+    screen -L -dmS node1 bash scripts/run-node.sh _build/old/terrad $DENOM
 else
-    screen -L -Logfile mytestnet/log-screen.txt -dmS node1 bash scripts/run-node.sh _build/new/terrad $DENOM
+    screen -L -Logfile mytestnet/log-screen.txt -dmS node1 bash scripts/run-node.sh _build/old/terrad $DENOM
 fi
 
 sleep 20
@@ -78,4 +78,5 @@ done
 
 sleep 5
 
+# run new node
 ./_build/new/terrad start --home $HOME


### PR DESCRIPTION
## Summary of changes
With the current `scripts/upgrade-test.sh` node will panic if the binary was updated before the upgrade height with following logs:
```
ERR BINARY UPDATED BEFORE TRIGGER! UPGRADE "v2" - in binary but not executed on chain
ERR CONSENSUS FAILURE!!! err="BINARY UPDATED BEFORE TRIGGER! UPGRADE \"v2\" - in binary but not executed on chain" module=consensus stack="goroutine 131 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:24 
```
This PR fixes `scripts/upgrade-test.sh` to use `old/terrad` as expected.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
