### PR TITLE
refactor: burn tax test

### DIFF
--- a/custom/auth/ante/burntax.go
+++ b/custom/auth/ante/burntax.go
@@ -120,15 +120,12 @@ func (btfd BurnTaxFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 			if burnSplitRate.IsPositive() {
 				communityDeltaCoins := sdk.NewCoins()
 
-				for i, taxCoin := range taxes {
+				for _, taxCoin := range taxes {
 					splitcoinAmount := burnSplitRate.MulInt(taxCoin.Amount).RoundInt()
-					splitCoin := sdk.NewCoin(taxCoin.Denom, splitcoinAmount)
-					taxes[i] = taxCoin.Sub(splitCoin)
-
-					if splitcoinAmount.IsPositive() {
-						communityDeltaCoins = communityDeltaCoins.Add(splitCoin)
-					}
+					communityDeltaCoins = communityDeltaCoins.Add(sdk.NewCoin(taxCoin.Denom, splitcoinAmount))
 				}
+
+				taxes = taxes.Sub(communityDeltaCoins)
 
 				if err = btfd.distrKeeper.FundCommunityPool(
 					ctx,


### PR DESCRIPTION
## Summary of changes
There are no changes in logic. Added -10% burn split rate (which is an invalid value) test to ensure that there are no problems when the burn tax split rate is negative.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [x] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
