### PR TITLE
Resolve possible golang version conflict

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+
+# Primary repo maintainers
+*       @ethanfrey
+*       @alpe

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:  
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: github.com/CosmWasm/wasmvm
+    versions:
+    - 0.14.0-beta2
+    - 0.14.0-beta3
+    - 0.14.0-beta4
+    - 0.14.0-beta5
+    - 0.14.0-rc1
+  - dependency-name: github.com/cometbft/cometbft
+    versions:
+    - 0.34.10
+    - 0.34.4
+    - 0.34.7
+    - 0.34.8
+    - 0.34.9
+  - dependency-name: github.com/cosmos/cosmos-sdk
+    versions:
+    - 0.41.4
+    - 0.42.0
+    - 0.42.1
+    - 0.42.2
+    - 0.42.4
+  - dependency-name: google.golang.org/grpc
+    versions:
+    - 1.36.0
+    - 1.36.1
+    - 1.37.0
+  - dependency-name: github.com/spf13/cobra
+    versions:
+    - 1.1.2
+  - dependency-name: github.com/cometbft/cometbft-db
+    versions:
+    - 0.6.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+---
+on: [push, pull_request]
+name: Build
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+      - run: go build ./...
+
+  tidy:
+    runs-on: ubuntu-latest
+    name: tidy
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+      - run: |
+          go mod tidy
+          CHANGES_IN_REPO=$(git status --porcelain)
+          if [[ -n "$CHANGES_IN_REPO" ]]; then
+            echo "Repository is dirty. Showing 'git status' and 'git --no-pager diff' for debugging now:"
+            git status && git --no-pager diff
+            exit 1
+          fi

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,0 +1,61 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow checks out code, performs a Codacy security scan
+# and integrates the results with the
+# GitHub Advanced Security code scanning feature.  For more information on
+# the Codacy security scan action usage and parameters, see
+# https://github.com/codacy/codacy-analysis-cli-action.
+# For more information on Codacy Analysis CLI in general, see
+# https://github.com/codacy/codacy-analysis-cli.
+
+name: Codacy Security Scan
+
+on:
+  push:
+    branches: [ "main", "release/v*" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main", "release/v*" ]
+  schedule:
+    - cron: '24 14 * * 5'
+
+permissions:
+  contents: read
+
+jobs:
+  codacy-security-scan:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Codacy Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
+      - name: Run Codacy Analysis CLI
+        uses: codacy/codacy-analysis-cli-action@d43127fe38d20c527dc1951ae5aea23148bab738
+        with:
+          # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
+          # You can also omit the token and run the tools that support default configurations
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          verbose: true
+          output: results.sarif
+          format: sarif
+          # Adjust severity of non-security issues
+          gh-code-scanning-compat: true
+          # Force 0 exit code to allow SARIF file generation
+          # This will handover control about PR rejection to the GitHub side
+          max-allowed-issues: 2147483647
+
+      # Upload the SARIF file generated in the previous step
+      - name: Upload SARIF results file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/codeql-analizer.yml
+++ b/.github/workflows/codeql-analizer.yml
@@ -1,19 +1,16 @@
-name: "CodeQL"
+name: "Code Scanning - Action"
 
 on:
   pull_request:
     paths:
       - "**.go"
   push:
-    branches:
-      - main
-      - release/v*
+    branches: [ main ]
     paths:
       - "**.go"
 
 jobs:
-  analyze:
-    name: Analyze
+  CodeQL-Build:
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -22,19 +19,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.20"
+        uses: actions/checkout@v3.3.0
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
-          languages: "go"
+          languages: 'go'
           queries: crypto-com/cosmos-sdk-codeql@main,security-and-quality
 
-      - name: Build
-        run: make build
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-cosmos.yml
+++ b/.github/workflows/codeql-cosmos.yml
@@ -1,4 +1,4 @@
-name: "CodeQL"
+name: "CodeQL for cosmos"
 
 on:
   pull_request:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,58 +1,23 @@
-name: Build & Push
-# Build & Push builds the simapp docker image on every push to master and
-# and pushes the image to https://hub.docker.com/r/interchainio/simapp/tags
+---
+name: Build Docker Image on PR
+
 on:
   pull_request:
-  push:
-    branches:
-      - main
-      - master
-      - "release/*"
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
-      - "v[0-9]+.[0-9]+.[0-9]+-rc*" # Push events to matching v*, i.e. v1.0-rc1, v20.15.10-rc5
 
 jobs:
-  build:
+  docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-        with:
-          fetch-depth: 0
-
-      - name: Prepare
-        id: prep
-        run: |
-          DOCKER_IMAGE=terramoney/core
-          VERSION=noop
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=latest
-            fi
-          fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
-          fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2 
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to Docker Hub
+      - name: Build without push
         uses: docker/build-push-action@v4
         with:
-          push: ${{ github.event_name != 'pull_request' && !contains(github.ref, 'release') }}
-          tags: ${{ steps.prep.outputs.tags }}
+          context: .
+          platforms: linux/amd64
+          push: false
+          build-args: arch=x86_64

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,34 @@
+---
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - release/v*
+      - main
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+      - uses: actions/checkout@v3
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --timeout 10m

--- a/.github/workflows/proto-buf-publisher.yml
+++ b/.github/workflows/proto-buf-publisher.yml
@@ -1,0 +1,38 @@
+name: Proto Buf Publishing - Action
+# Protobuf runs buf (https://buf.build/) push updated proto files to https://buf.build/cosmwasm/wasmd
+# This workflow is only run when a .proto file has been changed
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "proto/**"
+
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+.*" # Push events to matching v*, //i.e. v20.15.10, v0.27.0-rc1
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.3.0
+      - uses: bufbuild/buf-setup-action@v1.14.0
+
+      # lint checks
+      - uses: bufbuild/buf-lint-action@v1
+        with:
+          input: "proto"
+
+      # TODO: Add this when project is more stable.
+      # backward compatibility breaking checks
+      #- uses: bufbuild/buf-breaking-action@v1
+      #  with:
+      #    input: 'proto'
+      #    against: 'https://github.com/CosmWasm/wasmd.git#branch=master'
+
+      # publish proto files
+      - uses: bufbuild/buf-push-action@v1
+        with:
+          input: "proto"
+          buf_token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: "1.20"
       - name: Display go version
         run: go version
       - run: make build
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: "1.20"
       - name: Display go version
         run: go version
       - name: Install runsim
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: "1.20"
       - name: Display go version
         run: go version
       - uses: technote-space/get-diff-action@v4
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: "1.20"
       - name: Display go version
         run: go version
       - uses: technote-space/get-diff-action@v4
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: "1.20"
       - name: Display go version
         run: go version
       - uses: technote-space/get-diff-action@v4
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: "1.20"
       - name: Display go version
         run: go version
       - uses: technote-space/get-diff-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3.5.0
         with:
-          go-version: 1.18
+          go-version: "1.20"
       - uses: actions/checkout@v3
       - name: build
         run: |
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: "1.20"
       - uses: technote-space/get-diff-action@v4
         id: git_diff
         with:
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3.5.0
         with:
-          go-version: 1.18
+          go-version: "1.20"
       - uses: technote-space/get-diff-action@v4
         id: git_diff
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+---
+on: [push, pull_request]
+name: Test
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: test
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Test
+        run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.18
+go 1.20
 
 module github.com/classic-terra/core
 


### PR DESCRIPTION
- add code quality tooling that was removed by l1 team
- tidy and go 1.20

## Summary of changes

This PR reintroduces various pieces of automated code 
quality tooling, and bumps go in all places to v1.20.1

**this should be released as v1.1.1 and ALL VALIDATORS should attempt to use this build.  If this resolves the issue, then the problem was the go version.**

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
