### PR TITLE
add wasm-bindings for canonical wasmd

### DIFF
--- a/wasmbinding/bindings/msg.go
+++ b/wasmbinding/bindings/msg.go
@@ -1,0 +1,11 @@
+package bindings
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	markettypes "github.com/classic-terra/core/x/market/types"
+)
+
+type TerraMsg struct {
+	Swap     *markettypes.MsgSwap     `json:"swap,omitempty"`
+	SwapSend *markettypes.MsgSwapSend `json:"swap_send,omitempty"`
+}

--- a/wasmbinding/bindings/query.go
+++ b/wasmbinding/bindings/query.go
@@ -1,0 +1,22 @@
+package bindings
+
+import(
+	markettypes "github.com/classic-terra/core/x/market/types"
+	oracletypes "github.com/classic-terra/core/x/oracle/types"
+	treasurytypes "github.com/classic-terra/core/x/treasury/types"
+)
+
+// ExchangeRateQueryParams query request params for exchange rates
+type ExchangeRateQueryParams struct {
+	BaseDenom   string   `json:"base_denom"`
+	QuoteDenoms []string `json:"quote_denoms"`
+}
+
+// TerraQuery contains terra custom queries.
+type TerraQuery struct {
+	Swap *markettypes.QuerySwapParams `json:"swap,omitempty"`
+	ExchangeRates *ExchangeRateQueryParams `json:"exchange_rates,omitempty"`
+	TaxRate *struct{}                `json:"tax_rate,omitempty"`
+	TaxCap  *treasurytypes.QueryTaxCapParams `json:"tax_cap,omitempty"`
+}
+

--- a/wasmbinding/helper.go
+++ b/wasmbinding/helper.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // ConvertProtoToJsonMarshal  unmarshals the given bytes into a proto message and then marshals it to json.

--- a/wasmbinding/helper.go
+++ b/wasmbinding/helper.go
@@ -1,0 +1,59 @@
+package wasmbinding
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+)
+
+// ConvertProtoToJsonMarshal  unmarshals the given bytes into a proto message and then marshals it to json.
+// This is done so that clients calling stargate queries do not need to define their own proto unmarshalers,
+// being able to use response directly by json marshalling, which is supported in cosmwasm.
+func ConvertProtoToJSONMarshal(protoResponseType codec.ProtoMarshaler, bz []byte, cdc codec.Codec) ([]byte, error) {
+	// unmarshal binary into stargate response data structure
+	err := cdc.Unmarshal(bz, protoResponseType)
+	if err != nil {
+		return nil, wasmvmtypes.Unknown{}
+	}
+
+	bz, err = cdc.MarshalJSON(protoResponseType)
+	if err != nil {
+		return nil, wasmvmtypes.Unknown{}
+	}
+
+	protoResponseType.Reset()
+
+	return bz, nil
+}
+
+// ConvertSdkCoinsToWasmCoins converts sdk type coins to wasm vm type coins
+func ConvertSdkCoinsToWasmCoins(coins []sdk.Coin) wasmvmtypes.Coins {
+	var toSend wasmvmtypes.Coins
+	for _, coin := range coins {
+		c := ConvertSdkCoinToWasmCoin(coin)
+		toSend = append(toSend, c)
+	}
+	return toSend
+}
+
+// ConvertSdkCoinToWasmCoin converts a sdk type coin to a wasm vm type coin
+func ConvertSdkCoinToWasmCoin(coin sdk.Coin) wasmvmtypes.Coin {
+	return wasmvmtypes.Coin{
+		Denom: coin.Denom,
+		// Note: gamm tokens have 18 decimal places, so 10^22 is common, no longer in u64 range
+		Amount: coin.Amount.String(),
+	}
+}
+
+// parseAddress parses address from bech32 string and verifies its format.
+func parseAddress(addr string) (sdk.AccAddress, error) {
+	parsed, err := sdk.AccAddressFromBech32(addr)
+	if err != nil {
+		return nil, sdkerrors.Wrap(err, "address from bech32")
+	}
+	err = sdk.VerifyAddressFormat(parsed)
+	if err != nil {
+		return nil, sdkerrors.Wrap(err, "verify address format")
+	}
+	return parsed, nil
+}

--- a/wasmbinding/message_plugin.go
+++ b/wasmbinding/message_plugin.go
@@ -1,0 +1,167 @@
+package wasmbinding
+
+import (
+	"encoding/json"
+
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	//	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+
+	"github.com/classic-terra/core/wasmbinding/bindings"
+	marketkeeper "github.com/classic-terra/core/x/market/keeper"
+	markettypes "github.com/classic-terra/core/x/market/types"
+)
+
+// CustomMessageDecorator returns decorator for custom CosmWasm bindings messages
+func CustomMessageDecorator(market *marketkeeper.Keeper) func(wasmkeeper.Messenger) wasmkeeper.Messenger {
+	return func(old wasmkeeper.Messenger) wasmkeeper.Messenger {
+		return &CustomMessenger{
+			wrapped:      old,
+			marketKeeper: market,
+		}
+	}
+}
+
+type CustomMessenger struct {
+	wrapped      wasmkeeper.Messenger
+	marketKeeper *marketkeeper.Keeper
+}
+
+var _ wasmkeeper.Messenger = (*CustomMessenger)(nil)
+
+// DispatchMsg executes on the contractMsg.
+func (m *CustomMessenger) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) ([]sdk.Event, [][]byte, error) {
+	if msg.Custom != nil {
+		var contractMsg bindings.TerraMsg
+		if err := json.Unmarshal(msg.Custom, &contractMsg); err != nil {
+			return nil, nil, sdkerrors.Wrap(err, "terra msg")
+		}
+
+		switch {
+		case contractMsg.Swap != nil:
+			_, bz, err := m.swap(ctx, contractAddr, contractMsg.Swap)
+			if err != nil {
+				return nil, nil, sdkerrors.Wrap(err, "swap msg failed")
+			}
+			return nil, bz, nil
+
+		case contractMsg.SwapSend != nil:
+			_, bz, err := m.swapSend(ctx, contractAddr, contractMsg.SwapSend)
+			if err != nil {
+				return nil, nil, sdkerrors.Wrap(err, "swap msg failed")
+			}
+			return nil, bz, nil
+
+		default:
+			return nil, nil, wasmvmtypes.UnsupportedRequest{Kind: "unknown terra msg variant"}
+		}
+	}
+	return m.wrapped.DispatchMsg(ctx, contractAddr, contractIBCPortID, msg)
+}
+
+// swap wraps around performing market swap
+func (m *CustomMessenger) swap(ctx sdk.Context, contractAddr sdk.AccAddress, contractMsg *markettypes.MsgSwap) ([]sdk.Event, [][]byte, error) {
+	res, err := PerformSwap(m.marketKeeper, ctx, contractAddr, contractMsg)
+	if err != nil {
+		return nil, nil, sdkerrors.Wrap(err, "perform swap")
+	}
+
+	bz, err := json.Marshal(
+		markettypes.MsgSwapResponse{
+			SwapCoin: res.SwapCoin,
+			SwapFee:  res.SwapFee,
+		},
+	)
+	if err != nil {
+		return nil, nil, sdkerrors.Wrap(err, "error marshal swap response")
+	}
+
+	return nil, [][]byte{bz}, nil
+}
+
+// PerformSwap performs market swap
+func PerformSwap(f *marketkeeper.Keeper, ctx sdk.Context, contractAddr sdk.AccAddress, contractMsg *markettypes.MsgSwap) (*markettypes.MsgSwapResponse, error) {
+	if contractMsg == nil {
+		return nil, wasmvmtypes.InvalidRequest{Err: "market swap msg was null"}
+	}
+
+	msgServer := marketkeeper.NewMsgServerImpl(*f)
+
+	addr, err := parseAddress(contractAddr.String())
+	if err != nil {
+		return nil, sdkerrors.Wrap(err, "cannot verify sender address")
+	}
+
+	msgSwap := markettypes.NewMsgSwap(addr, contractMsg.OfferCoin, contractMsg.AskDenom)
+
+	if err := msgSwap.ValidateBasic(); err != nil {
+		return nil, sdkerrors.Wrap(err, "failed validating MsgSwap")
+	}
+
+	// swap
+	res, err := msgServer.Swap(
+		sdk.WrapSDKContext(ctx),
+		msgSwap,
+	)
+	if err != nil {
+		return nil, sdkerrors.Wrap(err, "swapping")
+	}
+	return res, nil
+}
+
+// swap wraps around performing market swap
+func (m *CustomMessenger) swapSend(ctx sdk.Context, contractAddr sdk.AccAddress, contractMsg *markettypes.MsgSwapSend) ([]sdk.Event, [][]byte, error) {
+	res, err := PerformSwapSend(m.marketKeeper, ctx, contractAddr, contractMsg)
+	if err != nil {
+		return nil, nil, sdkerrors.Wrap(err, "perform swap send")
+	}
+
+	bz, err := json.Marshal(
+		markettypes.MsgSwapSendResponse{
+			SwapCoin: res.SwapCoin,
+			SwapFee:  res.SwapFee,
+		},
+	)
+	if err != nil {
+		return nil, nil, sdkerrors.Wrap(err, "error marshal swap send response")
+	}
+
+	return nil, [][]byte{bz}, nil
+}
+
+// PerformSwapSend performs market swap
+func PerformSwapSend(f *marketkeeper.Keeper, ctx sdk.Context, contractAddr sdk.AccAddress, contractMsg *markettypes.MsgSwapSend) (*markettypes.MsgSwapSendResponse, error) {
+	if contractMsg == nil {
+		return nil, wasmvmtypes.InvalidRequest{Err: "market swap send msg was null"}
+	}
+
+	msgServer := marketkeeper.NewMsgServerImpl(*f)
+
+	addr, err := parseAddress(contractAddr.String())
+	if err != nil {
+		return nil, sdkerrors.Wrap(err, "swap send - cannot verify sender address")
+	}
+
+	toAddr, err := parseAddress(contractMsg.ToAddress)
+	if err != nil {
+		return nil, sdkerrors.Wrap(err, "swap send - cannot verify receiver address")
+	}
+
+	msgSwapSend := markettypes.NewMsgSwapSend(addr, toAddr, contractMsg.OfferCoin, contractMsg.AskDenom)
+
+	if err := msgSwapSend.ValidateBasic(); err != nil {
+		return nil, sdkerrors.Wrap(err, "failed validating MsgSwapSend")
+	}
+
+	// swap
+	res, err := msgServer.SwapSend(
+		sdk.WrapSDKContext(ctx),
+		msgSwapSend,
+	)
+	if err != nil {
+		return nil, sdkerrors.Wrap(err, "swapping and sending")
+	}
+	return res, nil
+}

--- a/wasmbinding/queries.go
+++ b/wasmbinding/queries.go
@@ -1,0 +1,27 @@
+package wasmbinding
+
+import (
+//	"fmt"
+
+//	sdk "github.com/cosmos/cosmos-sdk/types"
+
+//	"github.com/classic-terra/core/wasmbinding/bindings"
+	marketkeeper "github.com/classic-terra/core/x/market/keeper"
+	oraclekeeper "github.com/classic-terra/core/x/oracle/keeper"
+	treasurykeeper "github.com/classic-terra/core/x/treasury/keeper"
+)
+
+type QueryPlugin struct {
+	marketKeeper *marketkeeper.Keeper
+	oracleKeeper *oraclekeeper.Keeper
+	treasuryKeeper *treasurykeeper.Keeper
+}
+
+// NewQueryPlugin returns a reference to a new QueryPlugin.
+func NewQueryPlugin(tmk *marketkeeper.Keeper, tok *oraclekeeper.Keeper, ttk *treasurykeeper.Keeper) *QueryPlugin {
+	return &QueryPlugin{
+		marketKeeper: tmk,
+		oracleKeeper: tok,
+		treasuryKeeper: ttk,
+	}
+}

--- a/wasmbinding/query_plugin.go
+++ b/wasmbinding/query_plugin.go
@@ -94,11 +94,11 @@ func CustomQuerier(qp *QueryPlugin) func(ctx sdk.Context, request json.RawMessag
 				ExchangeRates: items,
 			})
 
-		if err != nil {
-			return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
-		}
+			if err != nil {
+				return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+			}
 
-		return bz, nil
+			return bz, nil
 		
 		case contractQuery.TaxRate != nil:
 			rate := qp.treasuryKeeper.GetTaxRate(ctx)

--- a/wasmbinding/query_plugin.go
+++ b/wasmbinding/query_plugin.go
@@ -1,0 +1,125 @@
+package wasmbinding
+
+import (
+	"encoding/json"
+
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/classic-terra/core/wasmbinding/bindings"
+	markettypes "github.com/classic-terra/core/x/market/types"
+	marketkeeper "github.com/classic-terra/core/x/market/keeper"
+)
+
+// SwapQueryResponse - swap simulation query response for wasm module
+type SwapQueryResponse struct {
+	Receive wasmvmtypes.Coin `json:"receive"`
+}
+
+// ExchangeRatesQueryResponseItem - exchange rates query response item
+type ExchangeRateItem struct {
+	ExchangeRate string `json:"exchange_rate"`
+	QuoteDenom   string `json:"quote_denom"`
+}
+
+// ExchangeRatesQueryResponse - exchange rates query response for wasm module
+type ExchangeRatesQueryResponse struct {
+	ExchangeRates []ExchangeRateItem `json:"exchange_rates"`
+	BaseDenom     string             `json:"base_denom"`
+}
+
+// TaxRateQueryResponse - tax rate query response for wasm module
+type TaxRateQueryResponse struct {
+	// decimal string, eg "0.02"
+	Rate string `json:"rate"`
+}
+
+// TaxCapQueryResponse - tax cap query response for wasm module
+type TaxCapQueryResponse struct {
+	// uint64 string, eg "1000000"
+	Cap string `json:"cap"`
+}
+
+// CustomQuerier dispatches custom CosmWasm bindings queries.
+func CustomQuerier(qp *QueryPlugin) func(ctx sdk.Context, request json.RawMessage) ([]byte, error) {
+	return func(ctx sdk.Context, request json.RawMessage) ([]byte, error) {
+		var contractQuery bindings.TerraQuery
+		if err := json.Unmarshal(request, &contractQuery); err != nil {
+			return nil, sdkerrors.Wrap(err, "terra query")
+		}
+
+		switch {
+		case contractQuery.Swap != nil:
+			q := marketkeeper.NewQuerier(*qp.marketKeeper)
+			res, err := q.Swap(sdk.WrapSDKContext(ctx), &markettypes.QuerySwapRequest{
+				OfferCoin: contractQuery.Swap.OfferCoin.String(),
+				AskDenom:  contractQuery.Swap.AskDenom,
+			})
+			if err != nil {
+				return nil, err
+			}
+			
+			bz, err := json.Marshal(SwapQueryResponse{Receive: ConvertSdkCoinToWasmCoin(res.ReturnCoin)})
+			if err != nil {
+				return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+			}
+
+			return bz, nil
+
+		case contractQuery.ExchangeRates != nil:
+			// LUNA / BASE_DENOM
+			baseDenomExchangeRate, err := qp.oracleKeeper.GetLunaExchangeRate(ctx, contractQuery.ExchangeRates.BaseDenom)
+			if err != nil {
+				return nil, err
+			}
+
+			var items []ExchangeRateItem
+			for _, quoteDenom := range contractQuery.ExchangeRates.QuoteDenoms {
+				// LUNA / QUOTE_DENOM
+				quoteDenomExchangeRate, err := qp.oracleKeeper.GetLunaExchangeRate(ctx, quoteDenom)
+				if err != nil {
+					continue
+				}
+
+				// (LUNA / QUOTE_DENOM) / (BASE_DENOM / LUNA) = BASE_DENOM / QUOTE_DENOM
+				items = append(items, ExchangeRateItem{
+					ExchangeRate: quoteDenomExchangeRate.Quo(baseDenomExchangeRate).String(),
+					QuoteDenom:   quoteDenom,
+				})
+			}
+
+			bz, err := json.Marshal(ExchangeRatesQueryResponse{
+				BaseDenom:     contractQuery.ExchangeRates.BaseDenom,
+				ExchangeRates: items,
+			})
+
+		if err != nil {
+			return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		}
+
+		return bz, nil
+		
+		case contractQuery.TaxRate != nil:
+			rate := qp.treasuryKeeper.GetTaxRate(ctx)
+			bz, err := json.Marshal(TaxRateQueryResponse{Rate: rate.String()})
+			if err != nil {
+				return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+			}
+			
+			return bz, nil
+		
+		case contractQuery.TaxCap != nil:
+			cap := qp.treasuryKeeper.GetTaxCap(ctx, contractQuery.TaxCap.Denom)
+			bz, err := json.Marshal(TaxCapQueryResponse{Cap: cap.String()})
+			if err != nil {
+				return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+			}
+		
+			return bz, nil
+
+		default:
+			return nil, wasmvmtypes.UnsupportedRequest{Kind: "unknown terra query variant"}
+		}
+	}
+}

--- a/wasmbinding/wasm.go
+++ b/wasmbinding/wasm.go
@@ -1,0 +1,38 @@
+package wasmbinding
+
+import (
+	"github.com/CosmWasm/wasmd/x/wasm"
+
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	//	"github.com/cosmos/cosmos-sdk/baseapp"
+	//	"github.com/cosmos/cosmos-sdk/codec"
+
+	marketkeeper "github.com/classic-terra/core/x/market/keeper"
+	oraclekeeper "github.com/classic-terra/core/x/oracle/keeper"
+	treasurykeeper "github.com/classic-terra/core/x/treasury/keeper"
+	// tokenfactorykeeper "github.com/osmosis-labs/osmosis/v15/x/tokenfactory/keeper"
+)
+
+func RegisterCustomPlugins(
+	marketKeeper *marketkeeper.Keeper,
+	oracleKeeper *oraclekeeper.Keeper,
+	treasuryKeeper *treasurykeeper.Keeper,
+) []wasmkeeper.Option {
+	wasmQueryPlugin := NewQueryPlugin(
+		marketKeeper,
+		oracleKeeper,
+		treasuryKeeper,
+	)
+
+	queryPluginOpt := wasmkeeper.WithQueryPlugins(&wasmkeeper.QueryPlugins{
+		Custom: CustomQuerier(wasmQueryPlugin),
+	})
+	messengerDecoratorOpt := wasmkeeper.WithMessageHandlerDecorator(
+		CustomMessageDecorator(marketKeeper),
+	)
+
+	return []wasm.Option{
+		queryPluginOpt,
+		messengerDecoratorOpt,
+	}
+}


### PR DESCRIPTION
## Summary of changes

This adds wasmbindings/bindings folder. I will add more in the wasmbindings folder as I go. Introduces `TerraMsg` and `TerraQuery` types. These are the JSON bindings for the custom Messages and Queries from market/treasury/oracle module.

