### PR TITLE
fix some broken unit tests after switch to canonical wasmd

### DIFF
--- a/custom/auth/ante/ante_test.go
+++ b/custom/auth/ante/ante_test.go
@@ -27,6 +27,8 @@ import (
 
 	terraapp "github.com/classic-terra/core/app"
 	treasurytypes "github.com/classic-terra/core/x/treasury/types"
+	
+	"github.com/CosmWasm/wasmd/x/wasm"
 )
 
 // AnteTestSuite is a test suite to be used with ante handler tests.
@@ -42,10 +44,13 @@ type AnteTestSuite struct {
 
 // returns context and app with params set on account keeper
 func createTestApp(isCheckTx bool, tempDir string) (*terraapp.TerraApp, sdk.Context) {
+	
+	// TODO: we need to feed in custom binding here?
+	var wasmOpts []wasm.Option
 	app := terraapp.NewTerraApp(
 		log.NewNopLogger(), dbm.NewMemDB(), nil, true, map[int64]bool{},
 		tempDir, simapp.FlagPeriodValue, terraapp.MakeEncodingConfig(),
-		simapp.EmptyAppOptions{}, wasmconfig.DefaultConfig(),
+		simapp.EmptyAppOptions{}, wasmOpts,
 	)
 	ctx := app.BaseApp.NewContext(isCheckTx, tmproto.Header{})
 	app.AccountKeeper.SetParams(ctx, authtypes.DefaultParams())

--- a/custom/auth/ante/tax_test.go
+++ b/custom/auth/ante/tax_test.go
@@ -249,7 +249,13 @@ func (suite *AnteTestSuite) TestEnsureMempoolFeesInstantiateContract() {
 	// msg and signatures
 	sendAmount := int64(1000000)
 	sendCoins := sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, sendAmount))
-	msg := wasmtypes.NewMsgInstantiateContract(addr1, addr1, 0, []byte{}, sendCoins)
+	msg := &wasmtypes.MsgInstantiateContract{
+		Sender: addr1.String(),
+		Admin: addr1.String(),
+		CodeID: 0, 
+		Msg: []byte{},
+		Funds: sendCoins,
+	}
 
 	feeAmount := testdata.NewTestFeeAmount()
 	gasLimit := testdata.NewTestGasLimit()
@@ -301,7 +307,12 @@ func (suite *AnteTestSuite) TestEnsureMempoolFeesExecuteContract() {
 	// msg and signatures
 	sendAmount := int64(1000000)
 	sendCoins := sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, sendAmount))
-	msg := wasmtypes.NewMsgExecuteContract(addr1, addr1, []byte{}, sendCoins)
+	msg := &wasmtypes.MsgExecuteContract{
+		Sender: addr1.String(),
+		Contract: addr1.String(),
+		Msg: []byte{},
+		Funds: sendCoins,
+	}
 
 	feeAmount := testdata.NewTestFeeAmount()
 	gasLimit := testdata.NewTestGasLimit()
@@ -588,7 +599,13 @@ func (suite *AnteTestSuite) TestEnsureMempoolFeesInstantiateContractLunaTax() {
 	// msg and signatures
 	sendAmount := int64(1000000)
 	sendCoins := sdk.NewCoins(sdk.NewInt64Coin(core.MicroLunaDenom, sendAmount))
-	msg := wasmtypes.NewMsgInstantiateContract(addr1, addr1, 0, []byte{}, sendCoins)
+	msg := &wasmtypes.MsgInstantiateContract{
+		Sender: addr1.String(),
+		Admin: addr1.String(),
+		CodeID: 0,
+		Msg: []byte{},
+		Funds: sendCoins,
+	}
 
 	feeAmount := testdata.NewTestFeeAmount()
 	gasLimit := testdata.NewTestGasLimit()
@@ -646,7 +663,12 @@ func (suite *AnteTestSuite) TestEnsureMempoolFeesExecuteContractLunaTax() {
 	// msg and signatures
 	sendAmount := int64(1000000)
 	sendCoins := sdk.NewCoins(sdk.NewInt64Coin(core.MicroLunaDenom, sendAmount))
-	msg := wasmtypes.NewMsgExecuteContract(addr1, addr1, []byte{}, sendCoins)
+	msg := &wasmtypes.MsgExecuteContract{
+		Sender: addr1.String(),
+		Contract: addr1.String(),
+		Msg: []byte{},
+		Funds: sendCoins,
+	}
 
 	feeAmount := testdata.NewTestFeeAmount()
 	gasLimit := testdata.NewTestGasLimit()

--- a/wasmbinding/bindings/msg.go
+++ b/wasmbinding/bindings/msg.go
@@ -1,7 +1,7 @@
 package bindings
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
+//	sdk "github.com/cosmos/cosmos-sdk/types"
 	markettypes "github.com/classic-terra/core/x/market/types"
 )
 

--- a/wasmbinding/bindings/query.go
+++ b/wasmbinding/bindings/query.go
@@ -2,7 +2,7 @@ package bindings
 
 import(
 	markettypes "github.com/classic-terra/core/x/market/types"
-	oracletypes "github.com/classic-terra/core/x/oracle/types"
+//	oracletypes "github.com/classic-terra/core/x/oracle/types"
 	treasurytypes "github.com/classic-terra/core/x/treasury/types"
 )
 


### PR DESCRIPTION
## Summary of changes

This PR aims to fix the broken unit-tests on canonical-wasm branch. The fixes mostly relate to the fact that `NewMsgInstantiateContract` and `NewMsgExecuteContract` are not available in canonical wasmd.
