### PR TITLE
Update `sims.yml` to contain go 1.18

### DIFF
--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Display go version
         run: go version
       - name: Install runsim
-        run: export GO111MODULE="on" && go get github.com/cosmos/tools/cmd/runsim@v1.0.0
+        run: export GO111MODULE="on" && go install github.com/cosmos/tools/cmd/runsim@v1.0.0
       - uses: actions/cache@v3.2.5
         with:
           path: ~/go/bin

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip-sims')"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2.1.3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: 1.18
       - name: Display go version
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/setup-go@v2.1.3
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: 1.18
       - name: Display go version
@@ -50,8 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, install-runsim]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2.1.3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: 1.18
       - name: Display go version
@@ -76,8 +76,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, install-runsim]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2.1.3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: 1.18
       - name: Display go version
@@ -104,8 +104,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, install-runsim]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2.1.3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: 1.18
       - name: Display go version
@@ -132,8 +132,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, install-runsim]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2.1.3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: 1.18
       - name: Display go version

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Display go version
         run: go version
       - run: make build
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Display go version
         run: go version
       - name: Install runsim
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Display go version
         run: go version
       - uses: technote-space/get-diff-action@v4
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Display go version
         run: go version
       - uses: technote-space/get-diff-action@v4
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Display go version
         run: go version
       - uses: technote-space/get-diff-action@v4
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Display go version
         run: go version
       - uses: technote-space/get-diff-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2.1.3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3.5.0
         with:
-          go-version: 1.17
+          go-version: 1.18
       - uses: technote-space/get-diff-action@v4
         id: git_diff
         with:


### PR DESCRIPTION
For some reason this workflow still contained go 1.17. I stumbled across this in the canonical-wasm branch, where it actually breaks the workflow. I propose to update that to 1.18.

BTW: the liveness test contains go version 1.17 too... So probably a solution for #171 ?