### PR TITLE
Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
# Code quality initiative led by Notional Labs

## Summary of changes

* create dependabot.yml to automatically update github actions and software libraries used in lunc.  This is among the numerous changes that I authored and seem to have been reverted by l1tf.
  * as a consequence of this reversion, lunc is chock full of deprecated github actions and other libraries.  

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
