### PR TITLE
add default wasm config to init cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,10 +203,10 @@ benchmark:
 ###############################################################################
 
 lint:
-	sudo golangci-lint run --out-format=tab
+	golangci-lint run --out-format=tab
 
 lint-fix:
-	sudo golangci-lint run --fix --out-format=tab --issues-exit-code=0
+	golangci-lint run --fix --out-format=tab --issues-exit-code=0
 
 lint-strict:
 	find . -path './_build' -prune -o -type f -name '*.go' -exec gofumpt -w -l {} +

--- a/app/app.go
+++ b/app/app.go
@@ -213,7 +213,7 @@ func NewTerraApp(
 			DistributionKeeper: app.DistrKeeper,
 			FeeShareKeeper:     app.FeeShareKeeper,
 			GovKeeper:          app.GovKeeper,
-			WasmConfig:         wasmConfig,
+			WasmConfig:         &wasmConfig,
 			TXCounterStoreKey:  app.GetKey(wasm.StoreKey),
 		},
 	)

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -21,7 +21,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	wasm "github.com/CosmWasm/wasmd/x/wasm"
 	feesharetypes "github.com/classic-terra/core/x/feeshare/types"
 	markettypes "github.com/classic-terra/core/x/market/types"
 	oracletypes "github.com/classic-terra/core/x/oracle/types"
@@ -47,7 +47,7 @@ func (appKeepers *AppKeepers) GenerateKeys() {
 		oracletypes.StoreKey,
 		markettypes.StoreKey,
 		treasurytypes.StoreKey,
-		wasmtypes.StoreKey,
+		wasm.StoreKey,
 		authzkeeper.StoreKey,
 		feegrant.StoreKey,
 		feesharetypes.StoreKey,

--- a/app/modules.go
+++ b/app/modules.go
@@ -94,7 +94,7 @@ var (
 		customdistr.AppModuleBasic{},
 		customgov.NewAppModuleBasic(
 			append(
-				wasmclient.ProposalHandlers, //nolint:staticcheck
+				wasmclient.ProposalHandlers,
 				paramsclient.ProposalHandler,
 				distrclient.ProposalHandler,
 				upgradeclient.ProposalHandler,

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
-	"github.com/cosmos/cosmos-sdk/codec"
 	terraapp "github.com/classic-terra/core/app"
 	"github.com/classic-terra/core/app/helpers"
+	"github.com/cosmos/cosmos-sdk/codec"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
@@ -21,20 +21,20 @@ import (
 	"github.com/cosmos/cosmos-sdk/simapp"
 	"github.com/cosmos/cosmos-sdk/store"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	simulation2 "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
-	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 )
 
 // interBlockCacheOpt returns a BaseApp option function that sets the persistent
 // inter-block write-through cache.
 func interBlockCacheOpt() func(*baseapp.BaseApp) {
-       return baseapp.SetInterBlockCache(store.NewCommitKVStoreCacheManager())
+	return baseapp.SetInterBlockCache(store.NewCommitKVStoreCacheManager())
 }
 
 // fauxMerkleModeOpt is a BaseApp option function to enable faux Merkle Tree mode for faster sim speed
 func fauxMerkleModeOpt() func(*baseapp.BaseApp) {
-	return func (app *baseapp.BaseApp)  { app.SetFauxMerkleMode() }
+	return func(app *baseapp.BaseApp) { app.SetFauxMerkleMode() }
 }
 
 func init() {

--- a/cmd/terrad/config.go
+++ b/cmd/terrad/config.go
@@ -2,29 +2,10 @@ package main
 
 import (
 	"fmt"
-//	servertypes "github.com/cosmos/cosmos-sdk/server/types"
-	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	//	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 )
-
-const (
-	defaultMemoryCacheSize    uint32 = 100 // in MiB
-	defaultSmartQueryGasLimit uint64 = 3_000_000
-	defaultContractDebugMode         = false
-)
-
-
-type WasmConfig struct {
-	// SimulationGasLimit is the max gas to be used in a tx simulation call.
-	// When not set the consensus max block gas is used instead
-	SimulationGasLimit *uint64 `mapstructure:"simulation_gas_limit"`
-	// SmartQueryGasLimit is the max gas to be used in a smart query contract call
-	SmartQueryGasLimit uint64 `mapstructure:"query_gas_limit"`
-	// MemoryCacheSize in MiB not bytes
-	MemoryCacheSize uint32 `mapstructure:"memory_cache_size"`
-	// ContractDebugMode log what contract print
-	ContractDebugMode bool
-}
 
 // TerraAppConfig terra specify app config
 type TerraAppConfig struct {
@@ -32,17 +13,8 @@ type TerraAppConfig struct {
 	Wasm wasmtypes.WasmConfig `mapstructure:"wasm"`
 }
 
-// DefaultWasmConfig returns the default settings for WasmConfig
-func DefaultWasmConfig() WasmConfig {
-	return WasmConfig{
-		SmartQueryGasLimit: defaultSmartQueryGasLimit,
-		MemoryCacheSize:    defaultMemoryCacheSize,
-		ContractDebugMode:  defaultContractDebugMode,
-	}
-}
-
 // ConfigTemplate toml snippet for app.toml
-func WasmConfigTemplate(c WasmConfig) string {
+func WasmConfigTemplate(c wasmtypes.WasmConfig) string {
 	simGasLimit := `# simulation_gas_limit =`
 	if c.SimulationGasLimit != nil {
 		simGasLimit = fmt.Sprintf(`simulation_gas_limit = %d`, *c.SimulationGasLimit)
@@ -70,7 +42,7 @@ memory_cache_size = %d
 
 // DefaultConfigTemplate toml snippet with default values for app.toml
 func DefaultWasmConfigTemplate() string {
-	return WasmConfigTemplate(DefaultWasmConfig())
+	return WasmConfigTemplate(wasmtypes.DefaultWasmConfig())
 }
 
 // initAppConfig helps to override default appConfig template and configs.
@@ -95,8 +67,8 @@ func initAppConfig() (string, interface{}) {
 	srvCfg.MinGasPrices = "0uluna"
 
 	terraAppConfig := TerraAppConfig{
-		Config:     *srvCfg,
-		Wasm: wasmtypes.DefaultWasmConfig(),
+		Config: *srvCfg,
+		Wasm:   wasmtypes.DefaultWasmConfig(),
 	}
 
 	terraAppTemplate := serverconfig.DefaultConfigTemplate + DefaultWasmConfigTemplate()

--- a/cmd/terrad/config.go
+++ b/cmd/terrad/config.go
@@ -1,16 +1,76 @@
 package main
 
 import (
+	"fmt"
 //	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
-//	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 )
+
+const (
+	defaultMemoryCacheSize    uint32 = 100 // in MiB
+	defaultSmartQueryGasLimit uint64 = 3_000_000
+	defaultContractDebugMode         = false
+)
+
+
+type WasmConfig struct {
+	// SimulationGasLimit is the max gas to be used in a tx simulation call.
+	// When not set the consensus max block gas is used instead
+	SimulationGasLimit *uint64 `mapstructure:"simulation_gas_limit"`
+	// SmartQueryGasLimit is the max gas to be used in a smart query contract call
+	SmartQueryGasLimit uint64 `mapstructure:"query_gas_limit"`
+	// MemoryCacheSize in MiB not bytes
+	MemoryCacheSize uint32 `mapstructure:"memory_cache_size"`
+	// ContractDebugMode log what contract print
+	ContractDebugMode bool
+}
 
 // TerraAppConfig terra specify app config
 type TerraAppConfig struct {
 	serverconfig.Config
+	Wasm wasmtypes.WasmConfig `mapstructure:"wasm"`
+}
 
-	//WASMConfig wasmtypes.WasmConfig `mapstructure:"wasm"`
+// DefaultWasmConfig returns the default settings for WasmConfig
+func DefaultWasmConfig() WasmConfig {
+	return WasmConfig{
+		SmartQueryGasLimit: defaultSmartQueryGasLimit,
+		MemoryCacheSize:    defaultMemoryCacheSize,
+		ContractDebugMode:  defaultContractDebugMode,
+	}
+}
+
+// ConfigTemplate toml snippet for app.toml
+func WasmConfigTemplate(c WasmConfig) string {
+	simGasLimit := `# simulation_gas_limit =`
+	if c.SimulationGasLimit != nil {
+		simGasLimit = fmt.Sprintf(`simulation_gas_limit = %d`, *c.SimulationGasLimit)
+	}
+
+	return fmt.Sprintf(`
+
+###############################################################################
+###                                  WASM                                   ###
+###############################################################################
+
+[wasm]
+# Smart query gas limit is the max gas to be used in a smart query contract call
+query_gas_limit = %d
+
+# in-memory cache for Wasm contracts. Set to 0 to disable.
+# The value is in MiB not bytes
+memory_cache_size = %d
+
+# Simulation gas limit is the max gas to be used in a tx simulation call.
+# When not set the consensus max block gas is used instead
+%s
+`, c.SmartQueryGasLimit, c.MemoryCacheSize, simGasLimit)
+}
+
+// DefaultConfigTemplate toml snippet with default values for app.toml
+func DefaultWasmConfigTemplate() string {
+	return WasmConfigTemplate(DefaultWasmConfig())
 }
 
 // initAppConfig helps to override default appConfig template and configs.
@@ -36,10 +96,10 @@ func initAppConfig() (string, interface{}) {
 
 	terraAppConfig := TerraAppConfig{
 		Config:     *srvCfg,
-		//WASMConfig: wasmtypes.DefaultWasmConfig(),
+		Wasm: wasmtypes.DefaultWasmConfig(),
 	}
 
-	terraAppTemplate := serverconfig.DefaultConfigTemplate //+ wasmconfig.DefaultConfigTemplate
+	terraAppTemplate := serverconfig.DefaultConfigTemplate + DefaultWasmConfigTemplate()
 
 	return terraAppTemplate, terraAppConfig
 }

--- a/cmd/terrad/root.go
+++ b/cmd/terrad/root.go
@@ -250,8 +250,8 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, a
 
 func (a appCreator) appExport(
 	logger log.Logger, db dbm.DB, traceStore io.Writer, height int64, forZeroHeight bool, jailAllowedAddrs []string,
-	appOpts servertypes.AppOptions) (servertypes.ExportedApp, error) {
-
+	appOpts servertypes.AppOptions,
+) (servertypes.ExportedApp, error) {
 	var wasmOpts []wasm.Option
 	homePath, ok := appOpts.Get(flags.FlagHome).(string)
 	if !ok || homePath == "" {

--- a/cmd/terrad/root.go
+++ b/cmd/terrad/root.go
@@ -130,6 +130,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 
 func addModuleInitFlags(startCmd *cobra.Command) {
 	crisis.AddModuleInitFlags(startCmd)
+	wasm.AddModuleInitFlags(startCmd)
 }
 
 func queryCommand() *cobra.Command {

--- a/custom/auth/ante/ante.go
+++ b/custom/auth/ante/ante.go
@@ -7,7 +7,6 @@ import (
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	feehshareante "github.com/classic-terra/core/x/feeshare/ante"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	cosmosante "github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -29,8 +28,8 @@ type HandlerOptions struct {
 	DistributionKeeper distributionkeeper.Keeper
 	GovKeeper          govkeeper.Keeper
 	FeeShareKeeper     feehshareante.FeeShareKeeper
-	WasmConfig         wasmtypes.WasmConfig
-	TXCounterStoreKey  storetypes.StoreKey
+	WasmConfig         *wasmtypes.WasmConfig
+	TXCounterStoreKey  sdk.StoreKey
 }
 
 // NewAnteHandler returns an AnteHandler that checks and increments sequence
@@ -59,6 +58,12 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 
 	if options.FeeShareKeeper == nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "fee share keeper is required for ante builder")
+	}
+	if options.WasmConfig == nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "wasm config is required for ante builder")
+	}
+	if options.TXCounterStoreKey == nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "tx counter key is required for ante builder")
 	}
 
 	sigGasConsumer := options.SigGasConsumer

--- a/custom/auth/ante/ante_test.go
+++ b/custom/auth/ante/ante_test.go
@@ -27,7 +27,7 @@ import (
 	terraapp "github.com/classic-terra/core/app"
 	feesharetypes "github.com/classic-terra/core/x/feeshare/types"
 	treasurytypes "github.com/classic-terra/core/x/treasury/types"
-	
+
 	"github.com/CosmWasm/wasmd/x/wasm"
 )
 
@@ -44,7 +44,6 @@ type AnteTestSuite struct {
 
 // returns context and app with params set on account keeper
 func createTestApp(isCheckTx bool, tempDir string) (*terraapp.TerraApp, sdk.Context) {
-	
 	// TODO: we need to feed in custom binding here?
 	var wasmOpts []wasm.Option
 	app := terraapp.NewTerraApp(

--- a/custom/auth/ante/integration_test.go
+++ b/custom/auth/ante/integration_test.go
@@ -3,6 +3,7 @@ package ante_test
 import (
 	"fmt"
 
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	customante "github.com/classic-terra/core/custom/auth/ante"
 	core "github.com/classic-terra/core/types"
 	treasurytypes "github.com/classic-terra/core/x/treasury/types"
@@ -129,6 +130,7 @@ func (suite *AnteTestSuite) TestIntegrationTaxExemption() {
 		burnModule := ak.GetModuleAccount(suite.ctx, treasurytypes.BurnModuleName)
 
 		encodingConfig := suite.SetupEncoding()
+		wasmConfig := wasmtypes.DefaultWasmConfig()
 		antehandler, err := customante.NewAnteHandler(
 			customante.HandlerOptions{
 				AccountKeeper:      ak,
@@ -141,11 +143,12 @@ func (suite *AnteTestSuite) TestIntegrationTaxExemption() {
 				IBCKeeper:          *suite.app.IBCKeeper,
 				DistributionKeeper: dk,
 				FeeShareKeeper:     fsk,
+				WasmConfig:         &wasmConfig,
+				TXCounterStoreKey:  suite.app.GetKey(wasmtypes.StoreKey),
 			},
 		)
 		suite.Require().NoError(err)
 
-		fmt.Printf("CASE = %s \n", c.name)
 		suite.ctx = suite.ctx.WithBlockHeight(customante.TaxPowerUpgradeHeight)
 		suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
 
@@ -161,51 +164,53 @@ func (suite *AnteTestSuite) TestIntegrationTaxExemption() {
 			bk.SendCoinsFromModuleToAccount(suite.ctx, minttypes.ModuleName, addrs[i], fundCoins)
 		}
 
-		// case 1 provides zero fee so not enough fee
-		// case 2 provides enough fee
-		feeCases := []int64{0, feeAmt}
-		for i := 0; i < 1; i++ {
-			feeAmount := sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, feeCases[i]))
-			gasLimit := testdata.NewTestGasLimit()
-			suite.Require().NoError(suite.txBuilder.SetMsgs(c.msgCreator()...))
-			suite.txBuilder.SetFeeAmount(feeAmount)
-			suite.txBuilder.SetGasLimit(gasLimit)
+		suite.Run(c.name, func() {
+			// case 1 provides zero fee so not enough fee
+			// case 2 provides enough fee
+			feeCases := []int64{0, feeAmt}
+			for i := 0; i < 1; i++ {
+				feeAmount := sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, feeCases[i]))
+				gasLimit := testdata.NewTestGasLimit()
+				suite.Require().NoError(suite.txBuilder.SetMsgs(c.msgCreator()...))
+				suite.txBuilder.SetFeeAmount(feeAmount)
+				suite.txBuilder.SetGasLimit(gasLimit)
 
-			privs, accNums, accSeqs := []cryptotypes.PrivKey{privs[c.msgSigner]}, []uint64{uint64(c.msgSigner)}, []uint64{uint64(i)}
-			tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
-			suite.Require().NoError(err)
-
-			feeCollectorBefore := bk.GetBalance(suite.ctx, feeCollector.GetAddress(), core.MicroSDRDenom)
-			burnBefore := bk.GetBalance(suite.ctx, burnModule.GetAddress(), core.MicroSDRDenom)
-			communityBefore := dk.GetFeePool(suite.ctx).CommunityPool.AmountOf(core.MicroSDRDenom)
-			supplyBefore := bk.GetSupply(suite.ctx, core.MicroSDRDenom)
-
-			_, err = antehandler(suite.ctx, tx, false)
-			if i == 0 && c.expectedFeeAmount != 0 {
-				suite.Require().EqualError(err, fmt.Sprintf("insufficient fees; got: \"\", required: \"%dusdr\" = \"\"(gas) +\"%dusdr\"(stability): insufficient fee", c.expectedFeeAmount, c.expectedFeeAmount))
-			} else {
+				privs, accNums, accSeqs := []cryptotypes.PrivKey{privs[c.msgSigner]}, []uint64{uint64(c.msgSigner)}, []uint64{uint64(i)}
+				tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
 				suite.Require().NoError(err)
-			}
 
-			feeCollectorAfter := bk.GetBalance(suite.ctx, feeCollector.GetAddress(), core.MicroSDRDenom)
-			burnAfter := bk.GetBalance(suite.ctx, burnModule.GetAddress(), core.MicroSDRDenom)
-			communityAfter := dk.GetFeePool(suite.ctx).CommunityPool.AmountOf(core.MicroSDRDenom)
-			supplyAfter := bk.GetSupply(suite.ctx, core.MicroSDRDenom)
+				feeCollectorBefore := bk.GetBalance(suite.ctx, feeCollector.GetAddress(), core.MicroSDRDenom)
+				burnBefore := bk.GetBalance(suite.ctx, burnModule.GetAddress(), core.MicroSDRDenom)
+				communityBefore := dk.GetFeePool(suite.ctx).CommunityPool.AmountOf(core.MicroSDRDenom)
+				supplyBefore := bk.GetSupply(suite.ctx, core.MicroSDRDenom)
 
-			if i == 0 {
-				suite.Require().Equal(feeCollectorBefore, feeCollectorAfter)
-				suite.Require().Equal(burnBefore, burnAfter)
-				suite.Require().Equal(communityBefore, communityAfter)
-				suite.Require().Equal(supplyBefore, supplyAfter)
-			}
+				_, err = antehandler(suite.ctx, tx, false)
+				if i == 0 && c.expectedFeeAmount != 0 {
+					suite.Require().EqualError(err, fmt.Sprintf("insufficient fees; got: \"\", required: \"%dusdr\" = \"\"(gas) +\"%dusdr\"(stability): insufficient fee", c.expectedFeeAmount, c.expectedFeeAmount))
+				} else {
+					suite.Require().NoError(err)
+				}
 
-			if i == 1 {
-				suite.Require().Equal(feeCollectorBefore, feeCollectorAfter)
-				splitAmount := sdk.NewInt(int64(float64(c.expectedFeeAmount) * 0.5))
-				suite.Require().Equal(burnBefore, burnAfter.AddAmount(splitAmount))
-				suite.Require().Equal(communityBefore, communityAfter.Add(sdk.NewDecFromInt(splitAmount)))
-				suite.Require().Equal(supplyBefore, supplyAfter.SubAmount(splitAmount))
+				feeCollectorAfter := bk.GetBalance(suite.ctx, feeCollector.GetAddress(), core.MicroSDRDenom)
+				burnAfter := bk.GetBalance(suite.ctx, burnModule.GetAddress(), core.MicroSDRDenom)
+				communityAfter := dk.GetFeePool(suite.ctx).CommunityPool.AmountOf(core.MicroSDRDenom)
+				supplyAfter := bk.GetSupply(suite.ctx, core.MicroSDRDenom)
+
+				if i == 0 {
+					suite.Require().Equal(feeCollectorBefore, feeCollectorAfter)
+					suite.Require().Equal(burnBefore, burnAfter)
+					suite.Require().Equal(communityBefore, communityAfter)
+					suite.Require().Equal(supplyBefore, supplyAfter)
+				}
+
+				if i == 1 {
+					suite.Require().Equal(feeCollectorBefore, feeCollectorAfter)
+					splitAmount := sdk.NewInt(int64(float64(c.expectedFeeAmount) * 0.5))
+					suite.Require().Equal(burnBefore, burnAfter.AddAmount(splitAmount))
+					suite.Require().Equal(communityBefore, communityAfter.Add(sdk.NewDecFromInt(splitAmount)))
+					suite.Require().Equal(supplyBefore, supplyAfter.SubAmount(splitAmount))
+				}
 			}
-		}
+		})
 	}
 }

--- a/custom/auth/ante/tax_test.go
+++ b/custom/auth/ante/tax_test.go
@@ -252,10 +252,10 @@ func (suite *AnteTestSuite) TestEnsureMempoolFeesInstantiateContract() {
 	sendCoins := sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, sendAmount))
 	msg := &wasmtypes.MsgInstantiateContract{
 		Sender: addr1.String(),
-		Admin: addr1.String(),
-		CodeID: 0, 
-		Msg: []byte{},
-		Funds: sendCoins,
+		Admin:  addr1.String(),
+		CodeID: 0,
+		Msg:    []byte{},
+		Funds:  sendCoins,
 	}
 
 	feeAmount := testdata.NewTestFeeAmount()
@@ -308,10 +308,10 @@ func (suite *AnteTestSuite) TestEnsureMempoolFeesExecuteContract() {
 	sendAmount := int64(1000000)
 	sendCoins := sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, sendAmount))
 	msg := &wasmtypes.MsgExecuteContract{
-		Sender: addr1.String(),
+		Sender:   addr1.String(),
 		Contract: addr1.String(),
-		Msg: []byte{},
-		Funds: sendCoins,
+		Msg:      []byte{},
+		Funds:    sendCoins,
 	}
 
 	feeAmount := testdata.NewTestFeeAmount()
@@ -601,10 +601,10 @@ func (suite *AnteTestSuite) TestEnsureMempoolFeesInstantiateContractLunaTax() {
 	sendCoins := sdk.NewCoins(sdk.NewInt64Coin(core.MicroLunaDenom, sendAmount))
 	msg := &wasmtypes.MsgInstantiateContract{
 		Sender: addr1.String(),
-		Admin: addr1.String(),
+		Admin:  addr1.String(),
 		CodeID: 0,
-		Msg: []byte{},
-		Funds: sendCoins,
+		Msg:    []byte{},
+		Funds:  sendCoins,
 	}
 
 	feeAmount := testdata.NewTestFeeAmount()
@@ -663,10 +663,10 @@ func (suite *AnteTestSuite) TestEnsureMempoolFeesExecuteContractLunaTax() {
 	sendAmount := int64(1000000)
 	sendCoins := sdk.NewCoins(sdk.NewInt64Coin(core.MicroLunaDenom, sendAmount))
 	msg := &wasmtypes.MsgExecuteContract{
-		Sender: addr1.String(),
+		Sender:   addr1.String(),
 		Contract: addr1.String(),
-		Msg: []byte{},
-		Funds: sendCoins,
+		Msg:      []byte{},
+		Funds:    sendCoins,
 	}
 
 	feeAmount := testdata.NewTestFeeAmount()

--- a/temp.txt
+++ b/temp.txt
@@ -1,0 +1,6 @@
+./_build/new/terrad tx wasm store wasmbinding/testdata/terra_reflect.wasm --from test --home mytestnet --chain-id test --keyring-backend test --gas-adjustment 2.5 --gas auto
+./_build/new/terrad tx wasm instantiate 1 '{}' --from test --home mytestnet --chain-id test --keyring-backend test --gas-adjustment 2.5 --gas auto --no-admin
+
+terra14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9ssrc8au
+
+./_build/new/terrad q wasm contract-state smart terra14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9ssrc8au '{"chain":{"request":{"custom":{"exchange_rates":{"base_denom":"uluna","quote_denoms":["uusd"]}}}}}'

--- a/wasmbinding/helper.go
+++ b/wasmbinding/helper.go
@@ -1,9 +1,9 @@
 package wasmbinding
 
 import (
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 

--- a/wasmbinding/message_plugin.go
+++ b/wasmbinding/message_plugin.go
@@ -96,7 +96,6 @@ func PerformSwap(f *marketkeeper.Keeper, ctx sdk.Context, contractAddr sdk.AccAd
 		sdk.WrapSDKContext(ctx),
 		msgSwap,
 	)
-
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "swapping")
 	}
@@ -142,7 +141,6 @@ func PerformSwapSend(f *marketkeeper.Keeper, ctx sdk.Context, contractAddr sdk.A
 		sdk.WrapSDKContext(ctx),
 		msgSwapSend,
 	)
-
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "swapping and sending")
 	}

--- a/wasmbinding/queries.go
+++ b/wasmbinding/queries.go
@@ -1,27 +1,27 @@
 package wasmbinding
 
 import (
-//	"fmt"
+	//	"fmt"
 
-//	sdk "github.com/cosmos/cosmos-sdk/types"
+	//	sdk "github.com/cosmos/cosmos-sdk/types"
 
-//	"github.com/classic-terra/core/wasmbinding/bindings"
+	//	"github.com/classic-terra/core/wasmbinding/bindings"
 	marketkeeper "github.com/classic-terra/core/x/market/keeper"
 	oraclekeeper "github.com/classic-terra/core/x/oracle/keeper"
 	treasurykeeper "github.com/classic-terra/core/x/treasury/keeper"
 )
 
 type QueryPlugin struct {
-	marketKeeper *marketkeeper.Keeper
-	oracleKeeper *oraclekeeper.Keeper
+	marketKeeper   *marketkeeper.Keeper
+	oracleKeeper   *oraclekeeper.Keeper
 	treasuryKeeper *treasurykeeper.Keeper
 }
 
 // NewQueryPlugin returns a reference to a new QueryPlugin.
 func NewQueryPlugin(tmk *marketkeeper.Keeper, tok *oraclekeeper.Keeper, ttk *treasurykeeper.Keeper) *QueryPlugin {
 	return &QueryPlugin{
-		marketKeeper: tmk,
-		oracleKeeper: tok,
+		marketKeeper:   tmk,
+		oracleKeeper:   tok,
 		treasuryKeeper: ttk,
 	}
 }

--- a/wasmbinding/query_plugin.go
+++ b/wasmbinding/query_plugin.go
@@ -70,7 +70,6 @@ func CustomQuerier(qp *QueryPlugin) func(ctx sdk.Context, request json.RawMessag
 				BaseDenom:     contractQuery.ExchangeRates.BaseDenom,
 				ExchangeRates: items,
 			})
-
 			if err != nil {
 				return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 			}

--- a/x/feeshare/ante/ante.go
+++ b/x/feeshare/ante/ante.go
@@ -5,8 +5,8 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
-	feeshare "github.com/classic-terra/core/x/feeshare/types"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	feeshare "github.com/classic-terra/core/x/feeshare/types"
 )
 
 // FeeSharePayoutDecorator Run his after we already deduct the fee from the account with

--- a/x/feeshare/ante/ante_test.go
+++ b/x/feeshare/ante/ante_test.go
@@ -25,10 +25,10 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 
-	feesharetypes "github.com/classic-terra/core/x/feeshare/types"
-	treasurytypes "github.com/classic-terra/core/x/treasury/types"
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	feesharetypes "github.com/classic-terra/core/x/feeshare/types"
+	treasurytypes "github.com/classic-terra/core/x/treasury/types"
 )
 
 var emptyWasmOpts []wasm.Option
@@ -247,10 +247,10 @@ func (suite *AnteTestSuite) TestFeeSharePayout() {
 
 	// Create msg for tx
 	msg := &wasmtypes.MsgExecuteContract{
-		Sender:     addr1.String(),
-		Contract:   addr1.String(),
-		Msg: []byte(`{"send":{}}`),
-		Funds:      sdk.NewCoins(sdk.NewCoin("utoken", sdk.NewInt(100))),
+		Sender:   addr1.String(),
+		Contract: addr1.String(),
+		Msg:      []byte(`{"send":{}}`),
+		Funds:    sdk.NewCoins(sdk.NewCoin("utoken", sdk.NewInt(100))),
 	}
 
 	require.NoError(suite.txBuilder.SetMsgs(msg))

--- a/x/feeshare/integration_test.go
+++ b/x/feeshare/integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/mint/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	
+
 	"github.com/CosmWasm/wasmd/x/wasm"
 )
 

--- a/x/feeshare/keeper/keeper.go
+++ b/x/feeshare/keeper/keeper.go
@@ -9,8 +9,8 @@ import (
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/tendermint/tendermint/libs/log"
 
-	revtypes "github.com/classic-terra/core/x/feeshare/types"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	revtypes "github.com/classic-terra/core/x/feeshare/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 

--- a/x/feeshare/types/feeshare.pb.go
+++ b/x/feeshare/types/feeshare.pb.go
@@ -5,16 +5,19 @@ package types
 
 import (
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -42,9 +45,11 @@ func (*FeeShare) ProtoMessage()    {}
 func (*FeeShare) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2ad55025c97efc46, []int{0}
 }
+
 func (m *FeeShare) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *FeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_FeeShare.Marshal(b, m, deterministic)
@@ -57,12 +62,15 @@ func (m *FeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *FeeShare) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_FeeShare.Merge(m, src)
 }
+
 func (m *FeeShare) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *FeeShare) XXX_DiscardUnknown() {
 	xxx_messageInfo_FeeShare.DiscardUnknown(m)
 }
@@ -171,6 +179,7 @@ func encodeVarintFeeshare(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *FeeShare) Size() (n int) {
 	if m == nil {
 		return 0
@@ -195,9 +204,11 @@ func (m *FeeShare) Size() (n int) {
 func sovFeeshare(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozFeeshare(x uint64) (n int) {
 	return sovFeeshare(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *FeeShare) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -344,6 +355,7 @@ func (m *FeeShare) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipFeeshare(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/feeshare/types/genesis.pb.go
+++ b/x/feeshare/types/genesis.pb.go
@@ -5,18 +5,21 @@ package types
 
 import (
 	fmt "fmt"
-	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
-	_ "github.com/cosmos/gogoproto/gogoproto"
-	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
+	_ "github.com/cosmos/gogoproto/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -38,9 +41,11 @@ func (*GenesisState) ProtoMessage()    {}
 func (*GenesisState) Descriptor() ([]byte, []int) {
 	return fileDescriptor_0b6781086762d348, []int{0}
 }
+
 func (m *GenesisState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *GenesisState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_GenesisState.Marshal(b, m, deterministic)
@@ -53,12 +58,15 @@ func (m *GenesisState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *GenesisState) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_GenesisState.Merge(m, src)
 }
+
 func (m *GenesisState) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *GenesisState) XXX_DiscardUnknown() {
 	xxx_messageInfo_GenesisState.DiscardUnknown(m)
 }
@@ -99,9 +107,11 @@ func (*Params) ProtoMessage()    {}
 func (*Params) Descriptor() ([]byte, []int) {
 	return fileDescriptor_0b6781086762d348, []int{1}
 }
+
 func (m *Params) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Params) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Params.Marshal(b, m, deterministic)
@@ -114,12 +124,15 @@ func (m *Params) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Params) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Params.Merge(m, src)
 }
+
 func (m *Params) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Params) XXX_DiscardUnknown() {
 	xxx_messageInfo_Params.DiscardUnknown(m)
 }
@@ -285,6 +298,7 @@ func encodeVarintGenesis(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *GenesisState) Size() (n int) {
 	if m == nil {
 		return 0
@@ -325,9 +339,11 @@ func (m *Params) Size() (n int) {
 func sovGenesis(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozGenesis(x uint64) (n int) {
 	return sovGenesis(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *GenesisState) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -445,6 +461,7 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Params) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -581,6 +598,7 @@ func (m *Params) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipGenesis(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/feeshare/types/query.pb.go
+++ b/x/feeshare/types/query.pb.go
@@ -6,6 +6,10 @@ package types
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	query "github.com/cosmos/cosmos-sdk/types/query"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/gogo/protobuf/grpc"
@@ -14,15 +18,14 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	io "io"
-	math "math"
-	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -42,9 +45,11 @@ func (*QueryFeeSharesRequest) ProtoMessage()    {}
 func (*QueryFeeSharesRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{0}
 }
+
 func (m *QueryFeeSharesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryFeeSharesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryFeeSharesRequest.Marshal(b, m, deterministic)
@@ -57,12 +62,15 @@ func (m *QueryFeeSharesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byt
 		return b[:n], nil
 	}
 }
+
 func (m *QueryFeeSharesRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryFeeSharesRequest.Merge(m, src)
 }
+
 func (m *QueryFeeSharesRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryFeeSharesRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryFeeSharesRequest.DiscardUnknown(m)
 }
@@ -91,9 +99,11 @@ func (*QueryFeeSharesResponse) ProtoMessage()    {}
 func (*QueryFeeSharesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{1}
 }
+
 func (m *QueryFeeSharesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryFeeSharesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryFeeSharesResponse.Marshal(b, m, deterministic)
@@ -106,12 +116,15 @@ func (m *QueryFeeSharesResponse) XXX_Marshal(b []byte, deterministic bool) ([]by
 		return b[:n], nil
 	}
 }
+
 func (m *QueryFeeSharesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryFeeSharesResponse.Merge(m, src)
 }
+
 func (m *QueryFeeSharesResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryFeeSharesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryFeeSharesResponse.DiscardUnknown(m)
 }
@@ -144,9 +157,11 @@ func (*QueryFeeShareRequest) ProtoMessage()    {}
 func (*QueryFeeShareRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{2}
 }
+
 func (m *QueryFeeShareRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryFeeShareRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryFeeShareRequest.Marshal(b, m, deterministic)
@@ -159,12 +174,15 @@ func (m *QueryFeeShareRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte
 		return b[:n], nil
 	}
 }
+
 func (m *QueryFeeShareRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryFeeShareRequest.Merge(m, src)
 }
+
 func (m *QueryFeeShareRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryFeeShareRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryFeeShareRequest.DiscardUnknown(m)
 }
@@ -190,9 +208,11 @@ func (*QueryFeeShareResponse) ProtoMessage()    {}
 func (*QueryFeeShareResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{3}
 }
+
 func (m *QueryFeeShareResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryFeeShareResponse.Marshal(b, m, deterministic)
@@ -205,12 +225,15 @@ func (m *QueryFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([]byt
 		return b[:n], nil
 	}
 }
+
 func (m *QueryFeeShareResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryFeeShareResponse.Merge(m, src)
 }
+
 func (m *QueryFeeShareResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryFeeShareResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryFeeShareResponse.DiscardUnknown(m)
 }
@@ -225,8 +248,7 @@ func (m *QueryFeeShareResponse) GetFeeshare() FeeShare {
 }
 
 // QueryParamsRequest is the request type for the Query/Params RPC method.
-type QueryParamsRequest struct {
-}
+type QueryParamsRequest struct{}
 
 func (m *QueryParamsRequest) Reset()         { *m = QueryParamsRequest{} }
 func (m *QueryParamsRequest) String() string { return proto.CompactTextString(m) }
@@ -234,9 +256,11 @@ func (*QueryParamsRequest) ProtoMessage()    {}
 func (*QueryParamsRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{4}
 }
+
 func (m *QueryParamsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryParamsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryParamsRequest.Marshal(b, m, deterministic)
@@ -249,12 +273,15 @@ func (m *QueryParamsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *QueryParamsRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryParamsRequest.Merge(m, src)
 }
+
 func (m *QueryParamsRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryParamsRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryParamsRequest.DiscardUnknown(m)
 }
@@ -273,9 +300,11 @@ func (*QueryParamsResponse) ProtoMessage()    {}
 func (*QueryParamsResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{5}
 }
+
 func (m *QueryParamsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryParamsResponse.Marshal(b, m, deterministic)
@@ -288,12 +317,15 @@ func (m *QueryParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
+
 func (m *QueryParamsResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryParamsResponse.Merge(m, src)
 }
+
 func (m *QueryParamsResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryParamsResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryParamsResponse.DiscardUnknown(m)
 }
@@ -322,9 +354,11 @@ func (*QueryDeployerFeeSharesRequest) ProtoMessage()    {}
 func (*QueryDeployerFeeSharesRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{6}
 }
+
 func (m *QueryDeployerFeeSharesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryDeployerFeeSharesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryDeployerFeeSharesRequest.Marshal(b, m, deterministic)
@@ -337,12 +371,15 @@ func (m *QueryDeployerFeeSharesRequest) XXX_Marshal(b []byte, deterministic bool
 		return b[:n], nil
 	}
 }
+
 func (m *QueryDeployerFeeSharesRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryDeployerFeeSharesRequest.Merge(m, src)
 }
+
 func (m *QueryDeployerFeeSharesRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryDeployerFeeSharesRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryDeployerFeeSharesRequest.DiscardUnknown(m)
 }
@@ -379,9 +416,11 @@ func (*QueryDeployerFeeSharesResponse) ProtoMessage()    {}
 func (*QueryDeployerFeeSharesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{7}
 }
+
 func (m *QueryDeployerFeeSharesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryDeployerFeeSharesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryDeployerFeeSharesResponse.Marshal(b, m, deterministic)
@@ -394,12 +433,15 @@ func (m *QueryDeployerFeeSharesResponse) XXX_Marshal(b []byte, deterministic boo
 		return b[:n], nil
 	}
 }
+
 func (m *QueryDeployerFeeSharesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryDeployerFeeSharesResponse.Merge(m, src)
 }
+
 func (m *QueryDeployerFeeSharesResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryDeployerFeeSharesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryDeployerFeeSharesResponse.DiscardUnknown(m)
 }
@@ -435,9 +477,11 @@ func (*QueryWithdrawerFeeSharesRequest) ProtoMessage()    {}
 func (*QueryWithdrawerFeeSharesRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{8}
 }
+
 func (m *QueryWithdrawerFeeSharesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryWithdrawerFeeSharesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryWithdrawerFeeSharesRequest.Marshal(b, m, deterministic)
@@ -450,12 +494,15 @@ func (m *QueryWithdrawerFeeSharesRequest) XXX_Marshal(b []byte, deterministic bo
 		return b[:n], nil
 	}
 }
+
 func (m *QueryWithdrawerFeeSharesRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryWithdrawerFeeSharesRequest.Merge(m, src)
 }
+
 func (m *QueryWithdrawerFeeSharesRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryWithdrawerFeeSharesRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryWithdrawerFeeSharesRequest.DiscardUnknown(m)
 }
@@ -492,9 +539,11 @@ func (*QueryWithdrawerFeeSharesResponse) ProtoMessage()    {}
 func (*QueryWithdrawerFeeSharesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{9}
 }
+
 func (m *QueryWithdrawerFeeSharesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryWithdrawerFeeSharesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryWithdrawerFeeSharesResponse.Marshal(b, m, deterministic)
@@ -507,12 +556,15 @@ func (m *QueryWithdrawerFeeSharesResponse) XXX_Marshal(b []byte, deterministic b
 		return b[:n], nil
 	}
 }
+
 func (m *QueryWithdrawerFeeSharesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryWithdrawerFeeSharesResponse.Merge(m, src)
 }
+
 func (m *QueryWithdrawerFeeSharesResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryWithdrawerFeeSharesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryWithdrawerFeeSharesResponse.DiscardUnknown(m)
 }
@@ -598,8 +650,10 @@ var fileDescriptor_4e589d86998f9341 = []byte{
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ context.Context
-var _ grpc.ClientConn
+var (
+	_ context.Context
+	_ grpc.ClientConn
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
@@ -693,21 +747,24 @@ type QueryServer interface {
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
-type UnimplementedQueryServer struct {
-}
+type UnimplementedQueryServer struct{}
 
 func (*UnimplementedQueryServer) FeeShares(ctx context.Context, req *QueryFeeSharesRequest) (*QueryFeeSharesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method FeeShares not implemented")
 }
+
 func (*UnimplementedQueryServer) FeeShare(ctx context.Context, req *QueryFeeShareRequest) (*QueryFeeShareResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method FeeShare not implemented")
 }
+
 func (*UnimplementedQueryServer) Params(ctx context.Context, req *QueryParamsRequest) (*QueryParamsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Params not implemented")
 }
+
 func (*UnimplementedQueryServer) DeployerFeeShares(ctx context.Context, req *QueryDeployerFeeSharesRequest) (*QueryDeployerFeeSharesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeployerFeeShares not implemented")
 }
+
 func (*UnimplementedQueryServer) WithdrawerFeeShares(ctx context.Context, req *QueryWithdrawerFeeSharesRequest) (*QueryWithdrawerFeeSharesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method WithdrawerFeeShares not implemented")
 }
@@ -1221,6 +1278,7 @@ func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *QueryFeeSharesRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1372,9 +1430,11 @@ func (m *QueryWithdrawerFeeSharesResponse) Size() (n int) {
 func sovQuery(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozQuery(x uint64) (n int) {
 	return sovQuery(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *QueryFeeSharesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1461,6 +1521,7 @@ func (m *QueryFeeSharesRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryFeeSharesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1581,6 +1642,7 @@ func (m *QueryFeeSharesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryFeeShareRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1663,6 +1725,7 @@ func (m *QueryFeeShareRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryFeeShareResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1746,6 +1809,7 @@ func (m *QueryFeeShareResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryParamsRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1796,6 +1860,7 @@ func (m *QueryParamsRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryParamsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1879,6 +1944,7 @@ func (m *QueryParamsResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryDeployerFeeSharesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1997,6 +2063,7 @@ func (m *QueryDeployerFeeSharesRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryDeployerFeeSharesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2115,6 +2182,7 @@ func (m *QueryDeployerFeeSharesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryWithdrawerFeeSharesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2233,6 +2301,7 @@ func (m *QueryWithdrawerFeeSharesRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryWithdrawerFeeSharesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2351,6 +2420,7 @@ func (m *QueryWithdrawerFeeSharesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipQuery(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/feeshare/types/query.pb.gw.go
+++ b/x/feeshare/types/query.pb.gw.go
@@ -25,17 +25,17 @@ import (
 )
 
 // Suppress "imported and not used" errors
-var _ codes.Code
-var _ io.Reader
-var _ status.Status
-var _ = runtime.String
-var _ = utilities.NewDoubleArray
-var _ = descriptor.ForMessage
-var _ = metadata.Join
-
 var (
-	filter_Query_FeeShares_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+	_ codes.Code
+	_ io.Reader
+	_ status.Status
+	_ = runtime.String
+	_ = utilities.NewDoubleArray
+	_ = descriptor.ForMessage
+	_ = metadata.Join
 )
+
+var filter_Query_FeeShares_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 
 func request_Query_FeeShares_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryFeeSharesRequest
@@ -50,7 +50,6 @@ func request_Query_FeeShares_0(ctx context.Context, marshaler runtime.Marshaler,
 
 	msg, err := client.FeeShares(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_FeeShares_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -66,7 +65,6 @@ func local_request_Query_FeeShares_0(ctx context.Context, marshaler runtime.Mars
 
 	msg, err := server.FeeShares(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
 func request_Query_FeeShare_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -93,7 +91,6 @@ func request_Query_FeeShare_0(ctx context.Context, marshaler runtime.Marshaler, 
 
 	msg, err := client.FeeShare(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_FeeShare_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -120,7 +117,6 @@ func local_request_Query_FeeShare_0(ctx context.Context, marshaler runtime.Marsh
 
 	msg, err := server.FeeShare(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
 func request_Query_Params_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -129,7 +125,6 @@ func request_Query_Params_0(ctx context.Context, marshaler runtime.Marshaler, cl
 
 	msg, err := client.Params(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_Params_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -138,12 +133,9 @@ func local_request_Query_Params_0(ctx context.Context, marshaler runtime.Marshal
 
 	msg, err := server.Params(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
-var (
-	filter_Query_DeployerFeeShares_0 = &utilities.DoubleArray{Encoding: map[string]int{"deployer_address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
-)
+var filter_Query_DeployerFeeShares_0 = &utilities.DoubleArray{Encoding: map[string]int{"deployer_address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 
 func request_Query_DeployerFeeShares_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryDeployerFeeSharesRequest
@@ -176,7 +168,6 @@ func request_Query_DeployerFeeShares_0(ctx context.Context, marshaler runtime.Ma
 
 	msg, err := client.DeployerFeeShares(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_DeployerFeeShares_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -210,12 +201,9 @@ func local_request_Query_DeployerFeeShares_0(ctx context.Context, marshaler runt
 
 	msg, err := server.DeployerFeeShares(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
-var (
-	filter_Query_WithdrawerFeeShares_0 = &utilities.DoubleArray{Encoding: map[string]int{"withdrawer_address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
-)
+var filter_Query_WithdrawerFeeShares_0 = &utilities.DoubleArray{Encoding: map[string]int{"withdrawer_address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 
 func request_Query_WithdrawerFeeShares_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryWithdrawerFeeSharesRequest
@@ -248,7 +236,6 @@ func request_Query_WithdrawerFeeShares_0(ctx context.Context, marshaler runtime.
 
 	msg, err := client.WithdrawerFeeShares(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_WithdrawerFeeShares_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -282,7 +269,6 @@ func local_request_Query_WithdrawerFeeShares_0(ctx context.Context, marshaler ru
 
 	msg, err := server.WithdrawerFeeShares(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
@@ -290,7 +276,6 @@ func local_request_Query_WithdrawerFeeShares_0(ctx context.Context, marshaler ru
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
 // Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterQueryHandlerFromEndpoint instead.
 func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, server QueryServer) error {
-
 	mux.Handle("GET", pattern_Query_FeeShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -311,7 +296,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_FeeShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_FeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -334,7 +318,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_FeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_Params_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -357,7 +340,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_Params_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_DeployerFeeShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -380,7 +362,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_DeployerFeeShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_WithdrawerFeeShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -403,7 +384,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_WithdrawerFeeShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	return nil
@@ -446,7 +426,6 @@ func RegisterQueryHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "QueryClient" to call the correct interceptors.
 func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, client QueryClient) error {
-
 	mux.Handle("GET", pattern_Query_FeeShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -464,7 +443,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_FeeShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_FeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -484,7 +462,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_FeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_Params_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -504,7 +481,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_Params_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_DeployerFeeShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -524,7 +500,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_DeployerFeeShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_WithdrawerFeeShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -544,7 +519,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_WithdrawerFeeShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	return nil

--- a/x/feeshare/types/tx.pb.go
+++ b/x/feeshare/types/tx.pb.go
@@ -6,6 +6,10 @@ package types
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/gogo/protobuf/grpc"
 	proto "github.com/gogo/protobuf/proto"
@@ -13,15 +17,14 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	io "io"
-	math "math"
-	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -47,9 +50,11 @@ func (*MsgRegisterFeeShare) ProtoMessage()    {}
 func (*MsgRegisterFeeShare) Descriptor() ([]byte, []int) {
 	return fileDescriptor_84f7f11948541b86, []int{0}
 }
+
 func (m *MsgRegisterFeeShare) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgRegisterFeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgRegisterFeeShare.Marshal(b, m, deterministic)
@@ -62,12 +67,15 @@ func (m *MsgRegisterFeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
+
 func (m *MsgRegisterFeeShare) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgRegisterFeeShare.Merge(m, src)
 }
+
 func (m *MsgRegisterFeeShare) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgRegisterFeeShare) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgRegisterFeeShare.DiscardUnknown(m)
 }
@@ -96,8 +104,7 @@ func (m *MsgRegisterFeeShare) GetWithdrawerAddress() string {
 }
 
 // MsgRegisterFeeShareResponse defines the MsgRegisterFeeShare response type
-type MsgRegisterFeeShareResponse struct {
-}
+type MsgRegisterFeeShareResponse struct{}
 
 func (m *MsgRegisterFeeShareResponse) Reset()         { *m = MsgRegisterFeeShareResponse{} }
 func (m *MsgRegisterFeeShareResponse) String() string { return proto.CompactTextString(m) }
@@ -105,9 +112,11 @@ func (*MsgRegisterFeeShareResponse) ProtoMessage()    {}
 func (*MsgRegisterFeeShareResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_84f7f11948541b86, []int{1}
 }
+
 func (m *MsgRegisterFeeShareResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgRegisterFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgRegisterFeeShareResponse.Marshal(b, m, deterministic)
@@ -120,12 +129,15 @@ func (m *MsgRegisterFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) 
 		return b[:n], nil
 	}
 }
+
 func (m *MsgRegisterFeeShareResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgRegisterFeeShareResponse.Merge(m, src)
 }
+
 func (m *MsgRegisterFeeShareResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgRegisterFeeShareResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgRegisterFeeShareResponse.DiscardUnknown(m)
 }
@@ -151,9 +163,11 @@ func (*MsgUpdateFeeShare) ProtoMessage()    {}
 func (*MsgUpdateFeeShare) Descriptor() ([]byte, []int) {
 	return fileDescriptor_84f7f11948541b86, []int{2}
 }
+
 func (m *MsgUpdateFeeShare) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgUpdateFeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateFeeShare.Marshal(b, m, deterministic)
@@ -166,12 +180,15 @@ func (m *MsgUpdateFeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
+
 func (m *MsgUpdateFeeShare) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateFeeShare.Merge(m, src)
 }
+
 func (m *MsgUpdateFeeShare) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgUpdateFeeShare) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateFeeShare.DiscardUnknown(m)
 }
@@ -200,8 +217,7 @@ func (m *MsgUpdateFeeShare) GetWithdrawerAddress() string {
 }
 
 // MsgUpdateFeeShareResponse defines the MsgUpdateFeeShare response type
-type MsgUpdateFeeShareResponse struct {
-}
+type MsgUpdateFeeShareResponse struct{}
 
 func (m *MsgUpdateFeeShareResponse) Reset()         { *m = MsgUpdateFeeShareResponse{} }
 func (m *MsgUpdateFeeShareResponse) String() string { return proto.CompactTextString(m) }
@@ -209,9 +225,11 @@ func (*MsgUpdateFeeShareResponse) ProtoMessage()    {}
 func (*MsgUpdateFeeShareResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_84f7f11948541b86, []int{3}
 }
+
 func (m *MsgUpdateFeeShareResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgUpdateFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateFeeShareResponse.Marshal(b, m, deterministic)
@@ -224,12 +242,15 @@ func (m *MsgUpdateFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
+
 func (m *MsgUpdateFeeShareResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateFeeShareResponse.Merge(m, src)
 }
+
 func (m *MsgUpdateFeeShareResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgUpdateFeeShareResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateFeeShareResponse.DiscardUnknown(m)
 }
@@ -251,9 +272,11 @@ func (*MsgCancelFeeShare) ProtoMessage()    {}
 func (*MsgCancelFeeShare) Descriptor() ([]byte, []int) {
 	return fileDescriptor_84f7f11948541b86, []int{4}
 }
+
 func (m *MsgCancelFeeShare) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgCancelFeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgCancelFeeShare.Marshal(b, m, deterministic)
@@ -266,12 +289,15 @@ func (m *MsgCancelFeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
+
 func (m *MsgCancelFeeShare) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgCancelFeeShare.Merge(m, src)
 }
+
 func (m *MsgCancelFeeShare) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgCancelFeeShare) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgCancelFeeShare.DiscardUnknown(m)
 }
@@ -293,8 +319,7 @@ func (m *MsgCancelFeeShare) GetDeployerAddress() string {
 }
 
 // MsgCancelFeeShareResponse defines the MsgCancelFeeShare response type
-type MsgCancelFeeShareResponse struct {
-}
+type MsgCancelFeeShareResponse struct{}
 
 func (m *MsgCancelFeeShareResponse) Reset()         { *m = MsgCancelFeeShareResponse{} }
 func (m *MsgCancelFeeShareResponse) String() string { return proto.CompactTextString(m) }
@@ -302,9 +327,11 @@ func (*MsgCancelFeeShareResponse) ProtoMessage()    {}
 func (*MsgCancelFeeShareResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_84f7f11948541b86, []int{5}
 }
+
 func (m *MsgCancelFeeShareResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgCancelFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgCancelFeeShareResponse.Marshal(b, m, deterministic)
@@ -317,12 +344,15 @@ func (m *MsgCancelFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
+
 func (m *MsgCancelFeeShareResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgCancelFeeShareResponse.Merge(m, src)
 }
+
 func (m *MsgCancelFeeShareResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgCancelFeeShareResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgCancelFeeShareResponse.DiscardUnknown(m)
 }
@@ -372,8 +402,10 @@ var fileDescriptor_84f7f11948541b86 = []byte{
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ context.Context
-var _ grpc.ClientConn
+var (
+	_ context.Context
+	_ grpc.ClientConn
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
@@ -439,15 +471,16 @@ type MsgServer interface {
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
-type UnimplementedMsgServer struct {
-}
+type UnimplementedMsgServer struct{}
 
 func (*UnimplementedMsgServer) RegisterFeeShare(ctx context.Context, req *MsgRegisterFeeShare) (*MsgRegisterFeeShareResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RegisterFeeShare not implemented")
 }
+
 func (*UnimplementedMsgServer) UpdateFeeShare(ctx context.Context, req *MsgUpdateFeeShare) (*MsgUpdateFeeShareResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateFeeShare not implemented")
 }
+
 func (*UnimplementedMsgServer) CancelFeeShare(ctx context.Context, req *MsgCancelFeeShare) (*MsgCancelFeeShareResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CancelFeeShare not implemented")
 }
@@ -736,6 +769,7 @@ func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *MsgRegisterFeeShare) Size() (n int) {
 	if m == nil {
 		return 0
@@ -825,9 +859,11 @@ func (m *MsgCancelFeeShareResponse) Size() (n int) {
 func sovTx(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTx(x uint64) (n int) {
 	return sovTx(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *MsgRegisterFeeShare) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -974,6 +1010,7 @@ func (m *MsgRegisterFeeShare) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgRegisterFeeShareResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1024,6 +1061,7 @@ func (m *MsgRegisterFeeShareResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgUpdateFeeShare) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1170,6 +1208,7 @@ func (m *MsgUpdateFeeShare) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgUpdateFeeShareResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1220,6 +1259,7 @@ func (m *MsgUpdateFeeShareResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgCancelFeeShare) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1334,6 +1374,7 @@ func (m *MsgCancelFeeShare) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgCancelFeeShareResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1384,6 +1425,7 @@ func (m *MsgCancelFeeShareResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTx(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/feeshare/types/tx.pb.gw.go
+++ b/x/feeshare/types/tx.pb.gw.go
@@ -25,17 +25,17 @@ import (
 )
 
 // Suppress "imported and not used" errors
-var _ codes.Code
-var _ io.Reader
-var _ status.Status
-var _ = runtime.String
-var _ = utilities.NewDoubleArray
-var _ = descriptor.ForMessage
-var _ = metadata.Join
-
 var (
-	filter_Msg_RegisterFeeShare_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+	_ codes.Code
+	_ io.Reader
+	_ status.Status
+	_ = runtime.String
+	_ = utilities.NewDoubleArray
+	_ = descriptor.ForMessage
+	_ = metadata.Join
 )
+
+var filter_Msg_RegisterFeeShare_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 
 func request_Msg_RegisterFeeShare_0(ctx context.Context, marshaler runtime.Marshaler, client MsgClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq MsgRegisterFeeShare
@@ -50,7 +50,6 @@ func request_Msg_RegisterFeeShare_0(ctx context.Context, marshaler runtime.Marsh
 
 	msg, err := client.RegisterFeeShare(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Msg_RegisterFeeShare_0(ctx context.Context, marshaler runtime.Marshaler, server MsgServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -66,12 +65,9 @@ func local_request_Msg_RegisterFeeShare_0(ctx context.Context, marshaler runtime
 
 	msg, err := server.RegisterFeeShare(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
-var (
-	filter_Msg_UpdateFeeShare_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
-)
+var filter_Msg_UpdateFeeShare_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 
 func request_Msg_UpdateFeeShare_0(ctx context.Context, marshaler runtime.Marshaler, client MsgClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq MsgUpdateFeeShare
@@ -86,7 +82,6 @@ func request_Msg_UpdateFeeShare_0(ctx context.Context, marshaler runtime.Marshal
 
 	msg, err := client.UpdateFeeShare(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Msg_UpdateFeeShare_0(ctx context.Context, marshaler runtime.Marshaler, server MsgServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -102,12 +97,9 @@ func local_request_Msg_UpdateFeeShare_0(ctx context.Context, marshaler runtime.M
 
 	msg, err := server.UpdateFeeShare(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
-var (
-	filter_Msg_CancelFeeShare_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
-)
+var filter_Msg_CancelFeeShare_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 
 func request_Msg_CancelFeeShare_0(ctx context.Context, marshaler runtime.Marshaler, client MsgClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq MsgCancelFeeShare
@@ -122,7 +114,6 @@ func request_Msg_CancelFeeShare_0(ctx context.Context, marshaler runtime.Marshal
 
 	msg, err := client.CancelFeeShare(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Msg_CancelFeeShare_0(ctx context.Context, marshaler runtime.Marshaler, server MsgServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -138,7 +129,6 @@ func local_request_Msg_CancelFeeShare_0(ctx context.Context, marshaler runtime.M
 
 	msg, err := server.CancelFeeShare(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
 // RegisterMsgHandlerServer registers the http handlers for service Msg to "mux".
@@ -146,7 +136,6 @@ func local_request_Msg_CancelFeeShare_0(ctx context.Context, marshaler runtime.M
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
 // Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterMsgHandlerFromEndpoint instead.
 func RegisterMsgHandlerServer(ctx context.Context, mux *runtime.ServeMux, server MsgServer) error {
-
 	mux.Handle("POST", pattern_Msg_RegisterFeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -167,7 +156,6 @@ func RegisterMsgHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 		}
 
 		forward_Msg_RegisterFeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("POST", pattern_Msg_UpdateFeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -190,7 +178,6 @@ func RegisterMsgHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 		}
 
 		forward_Msg_UpdateFeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("POST", pattern_Msg_CancelFeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -213,7 +200,6 @@ func RegisterMsgHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 		}
 
 		forward_Msg_CancelFeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	return nil
@@ -256,7 +242,6 @@ func RegisterMsgHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.C
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "MsgClient" to call the correct interceptors.
 func RegisterMsgHandlerClient(ctx context.Context, mux *runtime.ServeMux, client MsgClient) error {
-
 	mux.Handle("POST", pattern_Msg_RegisterFeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -274,7 +259,6 @@ func RegisterMsgHandlerClient(ctx context.Context, mux *runtime.ServeMux, client
 		}
 
 		forward_Msg_RegisterFeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("POST", pattern_Msg_UpdateFeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -294,7 +278,6 @@ func RegisterMsgHandlerClient(ctx context.Context, mux *runtime.ServeMux, client
 		}
 
 		forward_Msg_UpdateFeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("POST", pattern_Msg_CancelFeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -314,7 +297,6 @@ func RegisterMsgHandlerClient(ctx context.Context, mux *runtime.ServeMux, client
 		}
 
 		forward_Msg_CancelFeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	return nil


### PR DESCRIPTION
## Summary of changes

Add the default wasm config to the `app.toml` config template for `terrad init` command. Otherwise we may have ulimited contract query gas when someone creates a validator node from scratch.

**IMPORTANT**: We will also have to include this in upgrade instructions for the validators.