### PR TITLE
fix gas adjustment not being taken into account when calculating fees in `feeutils.go`

### DIFF
--- a/custom/auth/client/utils/feeutils.go
+++ b/custom/auth/client/utils/feeutils.go
@@ -172,7 +172,7 @@ func ComputeFeesWithCmd(
 
 	if !gasPrices.IsZero() {
 		glDec := sdk.NewDec(int64(gas))
-		adjustment := sdk.NewDecWithPrec(int64(txf.GasAdjustment()*100),2)
+		adjustment := sdk.NewDecWithPrec(int64(txf.GasAdjustment()*100), 2)
 
 		if adjustment.LT(sdk.OneDec()) {
 			adjustment = sdk.OneDec()

--- a/custom/auth/client/utils/feeutils.go
+++ b/custom/auth/client/utils/feeutils.go
@@ -172,12 +172,17 @@ func ComputeFeesWithCmd(
 
 	if !gasPrices.IsZero() {
 		glDec := sdk.NewDec(int64(gas))
+		adjustment := sdk.NewDecWithPrec(int64(txf.GasAdjustment()*100),2)
+
+		if adjustment.LT(sdk.OneDec()) {
+			adjustment = sdk.OneDec()
+		}
 
 		// Derive the fees based on the provided gas prices, where
 		// fee = ceil(gasPrice * gasLimit).
 		gasFees := make(sdk.Coins, len(gasPrices))
 		for i, gp := range gasPrices {
-			fee := gp.Amount.Mul(glDec)
+			fee := gp.Amount.Mul(glDec).Mul(adjustment)
 			gasFees[i] = sdk.NewCoin(gp.Denom, fee.Ceil().RoundInt())
 		}
 

--- a/x/feeshare/types/feeshare.pb.go
+++ b/x/feeshare/types/feeshare.pb.go
@@ -5,16 +5,19 @@ package types
 
 import (
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -42,9 +45,11 @@ func (*FeeShare) ProtoMessage()    {}
 func (*FeeShare) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2ad55025c97efc46, []int{0}
 }
+
 func (m *FeeShare) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *FeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_FeeShare.Marshal(b, m, deterministic)
@@ -57,12 +62,15 @@ func (m *FeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *FeeShare) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_FeeShare.Merge(m, src)
 }
+
 func (m *FeeShare) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *FeeShare) XXX_DiscardUnknown() {
 	xxx_messageInfo_FeeShare.DiscardUnknown(m)
 }
@@ -171,6 +179,7 @@ func encodeVarintFeeshare(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *FeeShare) Size() (n int) {
 	if m == nil {
 		return 0
@@ -195,9 +204,11 @@ func (m *FeeShare) Size() (n int) {
 func sovFeeshare(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozFeeshare(x uint64) (n int) {
 	return sovFeeshare(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *FeeShare) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -344,6 +355,7 @@ func (m *FeeShare) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipFeeshare(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/feeshare/types/genesis.pb.go
+++ b/x/feeshare/types/genesis.pb.go
@@ -5,18 +5,21 @@ package types
 
 import (
 	fmt "fmt"
-	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
-	_ "github.com/cosmos/gogoproto/gogoproto"
-	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
+	_ "github.com/cosmos/gogoproto/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -38,9 +41,11 @@ func (*GenesisState) ProtoMessage()    {}
 func (*GenesisState) Descriptor() ([]byte, []int) {
 	return fileDescriptor_0b6781086762d348, []int{0}
 }
+
 func (m *GenesisState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *GenesisState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_GenesisState.Marshal(b, m, deterministic)
@@ -53,12 +58,15 @@ func (m *GenesisState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *GenesisState) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_GenesisState.Merge(m, src)
 }
+
 func (m *GenesisState) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *GenesisState) XXX_DiscardUnknown() {
 	xxx_messageInfo_GenesisState.DiscardUnknown(m)
 }
@@ -99,9 +107,11 @@ func (*Params) ProtoMessage()    {}
 func (*Params) Descriptor() ([]byte, []int) {
 	return fileDescriptor_0b6781086762d348, []int{1}
 }
+
 func (m *Params) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Params) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Params.Marshal(b, m, deterministic)
@@ -114,12 +124,15 @@ func (m *Params) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Params) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Params.Merge(m, src)
 }
+
 func (m *Params) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Params) XXX_DiscardUnknown() {
 	xxx_messageInfo_Params.DiscardUnknown(m)
 }
@@ -285,6 +298,7 @@ func encodeVarintGenesis(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *GenesisState) Size() (n int) {
 	if m == nil {
 		return 0
@@ -325,9 +339,11 @@ func (m *Params) Size() (n int) {
 func sovGenesis(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozGenesis(x uint64) (n int) {
 	return sovGenesis(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *GenesisState) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -445,6 +461,7 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Params) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -581,6 +598,7 @@ func (m *Params) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipGenesis(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/feeshare/types/query.pb.go
+++ b/x/feeshare/types/query.pb.go
@@ -6,6 +6,10 @@ package types
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	query "github.com/cosmos/cosmos-sdk/types/query"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/gogo/protobuf/grpc"
@@ -14,15 +18,14 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	io "io"
-	math "math"
-	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -42,9 +45,11 @@ func (*QueryFeeSharesRequest) ProtoMessage()    {}
 func (*QueryFeeSharesRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{0}
 }
+
 func (m *QueryFeeSharesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryFeeSharesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryFeeSharesRequest.Marshal(b, m, deterministic)
@@ -57,12 +62,15 @@ func (m *QueryFeeSharesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byt
 		return b[:n], nil
 	}
 }
+
 func (m *QueryFeeSharesRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryFeeSharesRequest.Merge(m, src)
 }
+
 func (m *QueryFeeSharesRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryFeeSharesRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryFeeSharesRequest.DiscardUnknown(m)
 }
@@ -91,9 +99,11 @@ func (*QueryFeeSharesResponse) ProtoMessage()    {}
 func (*QueryFeeSharesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{1}
 }
+
 func (m *QueryFeeSharesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryFeeSharesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryFeeSharesResponse.Marshal(b, m, deterministic)
@@ -106,12 +116,15 @@ func (m *QueryFeeSharesResponse) XXX_Marshal(b []byte, deterministic bool) ([]by
 		return b[:n], nil
 	}
 }
+
 func (m *QueryFeeSharesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryFeeSharesResponse.Merge(m, src)
 }
+
 func (m *QueryFeeSharesResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryFeeSharesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryFeeSharesResponse.DiscardUnknown(m)
 }
@@ -144,9 +157,11 @@ func (*QueryFeeShareRequest) ProtoMessage()    {}
 func (*QueryFeeShareRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{2}
 }
+
 func (m *QueryFeeShareRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryFeeShareRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryFeeShareRequest.Marshal(b, m, deterministic)
@@ -159,12 +174,15 @@ func (m *QueryFeeShareRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte
 		return b[:n], nil
 	}
 }
+
 func (m *QueryFeeShareRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryFeeShareRequest.Merge(m, src)
 }
+
 func (m *QueryFeeShareRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryFeeShareRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryFeeShareRequest.DiscardUnknown(m)
 }
@@ -190,9 +208,11 @@ func (*QueryFeeShareResponse) ProtoMessage()    {}
 func (*QueryFeeShareResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{3}
 }
+
 func (m *QueryFeeShareResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryFeeShareResponse.Marshal(b, m, deterministic)
@@ -205,12 +225,15 @@ func (m *QueryFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([]byt
 		return b[:n], nil
 	}
 }
+
 func (m *QueryFeeShareResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryFeeShareResponse.Merge(m, src)
 }
+
 func (m *QueryFeeShareResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryFeeShareResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryFeeShareResponse.DiscardUnknown(m)
 }
@@ -225,8 +248,7 @@ func (m *QueryFeeShareResponse) GetFeeshare() FeeShare {
 }
 
 // QueryParamsRequest is the request type for the Query/Params RPC method.
-type QueryParamsRequest struct {
-}
+type QueryParamsRequest struct{}
 
 func (m *QueryParamsRequest) Reset()         { *m = QueryParamsRequest{} }
 func (m *QueryParamsRequest) String() string { return proto.CompactTextString(m) }
@@ -234,9 +256,11 @@ func (*QueryParamsRequest) ProtoMessage()    {}
 func (*QueryParamsRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{4}
 }
+
 func (m *QueryParamsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryParamsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryParamsRequest.Marshal(b, m, deterministic)
@@ -249,12 +273,15 @@ func (m *QueryParamsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *QueryParamsRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryParamsRequest.Merge(m, src)
 }
+
 func (m *QueryParamsRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryParamsRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryParamsRequest.DiscardUnknown(m)
 }
@@ -273,9 +300,11 @@ func (*QueryParamsResponse) ProtoMessage()    {}
 func (*QueryParamsResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{5}
 }
+
 func (m *QueryParamsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryParamsResponse.Marshal(b, m, deterministic)
@@ -288,12 +317,15 @@ func (m *QueryParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
+
 func (m *QueryParamsResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryParamsResponse.Merge(m, src)
 }
+
 func (m *QueryParamsResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryParamsResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryParamsResponse.DiscardUnknown(m)
 }
@@ -322,9 +354,11 @@ func (*QueryDeployerFeeSharesRequest) ProtoMessage()    {}
 func (*QueryDeployerFeeSharesRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{6}
 }
+
 func (m *QueryDeployerFeeSharesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryDeployerFeeSharesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryDeployerFeeSharesRequest.Marshal(b, m, deterministic)
@@ -337,12 +371,15 @@ func (m *QueryDeployerFeeSharesRequest) XXX_Marshal(b []byte, deterministic bool
 		return b[:n], nil
 	}
 }
+
 func (m *QueryDeployerFeeSharesRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryDeployerFeeSharesRequest.Merge(m, src)
 }
+
 func (m *QueryDeployerFeeSharesRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryDeployerFeeSharesRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryDeployerFeeSharesRequest.DiscardUnknown(m)
 }
@@ -379,9 +416,11 @@ func (*QueryDeployerFeeSharesResponse) ProtoMessage()    {}
 func (*QueryDeployerFeeSharesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{7}
 }
+
 func (m *QueryDeployerFeeSharesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryDeployerFeeSharesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryDeployerFeeSharesResponse.Marshal(b, m, deterministic)
@@ -394,12 +433,15 @@ func (m *QueryDeployerFeeSharesResponse) XXX_Marshal(b []byte, deterministic boo
 		return b[:n], nil
 	}
 }
+
 func (m *QueryDeployerFeeSharesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryDeployerFeeSharesResponse.Merge(m, src)
 }
+
 func (m *QueryDeployerFeeSharesResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryDeployerFeeSharesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryDeployerFeeSharesResponse.DiscardUnknown(m)
 }
@@ -435,9 +477,11 @@ func (*QueryWithdrawerFeeSharesRequest) ProtoMessage()    {}
 func (*QueryWithdrawerFeeSharesRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{8}
 }
+
 func (m *QueryWithdrawerFeeSharesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryWithdrawerFeeSharesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryWithdrawerFeeSharesRequest.Marshal(b, m, deterministic)
@@ -450,12 +494,15 @@ func (m *QueryWithdrawerFeeSharesRequest) XXX_Marshal(b []byte, deterministic bo
 		return b[:n], nil
 	}
 }
+
 func (m *QueryWithdrawerFeeSharesRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryWithdrawerFeeSharesRequest.Merge(m, src)
 }
+
 func (m *QueryWithdrawerFeeSharesRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryWithdrawerFeeSharesRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryWithdrawerFeeSharesRequest.DiscardUnknown(m)
 }
@@ -492,9 +539,11 @@ func (*QueryWithdrawerFeeSharesResponse) ProtoMessage()    {}
 func (*QueryWithdrawerFeeSharesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e589d86998f9341, []int{9}
 }
+
 func (m *QueryWithdrawerFeeSharesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryWithdrawerFeeSharesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryWithdrawerFeeSharesResponse.Marshal(b, m, deterministic)
@@ -507,12 +556,15 @@ func (m *QueryWithdrawerFeeSharesResponse) XXX_Marshal(b []byte, deterministic b
 		return b[:n], nil
 	}
 }
+
 func (m *QueryWithdrawerFeeSharesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryWithdrawerFeeSharesResponse.Merge(m, src)
 }
+
 func (m *QueryWithdrawerFeeSharesResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryWithdrawerFeeSharesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryWithdrawerFeeSharesResponse.DiscardUnknown(m)
 }
@@ -598,8 +650,10 @@ var fileDescriptor_4e589d86998f9341 = []byte{
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ context.Context
-var _ grpc.ClientConn
+var (
+	_ context.Context
+	_ grpc.ClientConn
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
@@ -693,21 +747,24 @@ type QueryServer interface {
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
-type UnimplementedQueryServer struct {
-}
+type UnimplementedQueryServer struct{}
 
 func (*UnimplementedQueryServer) FeeShares(ctx context.Context, req *QueryFeeSharesRequest) (*QueryFeeSharesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method FeeShares not implemented")
 }
+
 func (*UnimplementedQueryServer) FeeShare(ctx context.Context, req *QueryFeeShareRequest) (*QueryFeeShareResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method FeeShare not implemented")
 }
+
 func (*UnimplementedQueryServer) Params(ctx context.Context, req *QueryParamsRequest) (*QueryParamsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Params not implemented")
 }
+
 func (*UnimplementedQueryServer) DeployerFeeShares(ctx context.Context, req *QueryDeployerFeeSharesRequest) (*QueryDeployerFeeSharesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeployerFeeShares not implemented")
 }
+
 func (*UnimplementedQueryServer) WithdrawerFeeShares(ctx context.Context, req *QueryWithdrawerFeeSharesRequest) (*QueryWithdrawerFeeSharesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method WithdrawerFeeShares not implemented")
 }
@@ -1221,6 +1278,7 @@ func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *QueryFeeSharesRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1372,9 +1430,11 @@ func (m *QueryWithdrawerFeeSharesResponse) Size() (n int) {
 func sovQuery(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozQuery(x uint64) (n int) {
 	return sovQuery(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *QueryFeeSharesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1461,6 +1521,7 @@ func (m *QueryFeeSharesRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryFeeSharesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1581,6 +1642,7 @@ func (m *QueryFeeSharesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryFeeShareRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1663,6 +1725,7 @@ func (m *QueryFeeShareRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryFeeShareResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1746,6 +1809,7 @@ func (m *QueryFeeShareResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryParamsRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1796,6 +1860,7 @@ func (m *QueryParamsRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryParamsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1879,6 +1944,7 @@ func (m *QueryParamsResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryDeployerFeeSharesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1997,6 +2063,7 @@ func (m *QueryDeployerFeeSharesRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryDeployerFeeSharesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2115,6 +2182,7 @@ func (m *QueryDeployerFeeSharesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryWithdrawerFeeSharesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2233,6 +2301,7 @@ func (m *QueryWithdrawerFeeSharesRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryWithdrawerFeeSharesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2351,6 +2420,7 @@ func (m *QueryWithdrawerFeeSharesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipQuery(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/feeshare/types/query.pb.gw.go
+++ b/x/feeshare/types/query.pb.gw.go
@@ -25,17 +25,17 @@ import (
 )
 
 // Suppress "imported and not used" errors
-var _ codes.Code
-var _ io.Reader
-var _ status.Status
-var _ = runtime.String
-var _ = utilities.NewDoubleArray
-var _ = descriptor.ForMessage
-var _ = metadata.Join
-
 var (
-	filter_Query_FeeShares_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+	_ codes.Code
+	_ io.Reader
+	_ status.Status
+	_ = runtime.String
+	_ = utilities.NewDoubleArray
+	_ = descriptor.ForMessage
+	_ = metadata.Join
 )
+
+var filter_Query_FeeShares_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 
 func request_Query_FeeShares_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryFeeSharesRequest
@@ -50,7 +50,6 @@ func request_Query_FeeShares_0(ctx context.Context, marshaler runtime.Marshaler,
 
 	msg, err := client.FeeShares(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_FeeShares_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -66,7 +65,6 @@ func local_request_Query_FeeShares_0(ctx context.Context, marshaler runtime.Mars
 
 	msg, err := server.FeeShares(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
 func request_Query_FeeShare_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -93,7 +91,6 @@ func request_Query_FeeShare_0(ctx context.Context, marshaler runtime.Marshaler, 
 
 	msg, err := client.FeeShare(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_FeeShare_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -120,7 +117,6 @@ func local_request_Query_FeeShare_0(ctx context.Context, marshaler runtime.Marsh
 
 	msg, err := server.FeeShare(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
 func request_Query_Params_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -129,7 +125,6 @@ func request_Query_Params_0(ctx context.Context, marshaler runtime.Marshaler, cl
 
 	msg, err := client.Params(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_Params_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -138,12 +133,9 @@ func local_request_Query_Params_0(ctx context.Context, marshaler runtime.Marshal
 
 	msg, err := server.Params(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
-var (
-	filter_Query_DeployerFeeShares_0 = &utilities.DoubleArray{Encoding: map[string]int{"deployer_address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
-)
+var filter_Query_DeployerFeeShares_0 = &utilities.DoubleArray{Encoding: map[string]int{"deployer_address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 
 func request_Query_DeployerFeeShares_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryDeployerFeeSharesRequest
@@ -176,7 +168,6 @@ func request_Query_DeployerFeeShares_0(ctx context.Context, marshaler runtime.Ma
 
 	msg, err := client.DeployerFeeShares(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_DeployerFeeShares_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -210,12 +201,9 @@ func local_request_Query_DeployerFeeShares_0(ctx context.Context, marshaler runt
 
 	msg, err := server.DeployerFeeShares(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
-var (
-	filter_Query_WithdrawerFeeShares_0 = &utilities.DoubleArray{Encoding: map[string]int{"withdrawer_address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
-)
+var filter_Query_WithdrawerFeeShares_0 = &utilities.DoubleArray{Encoding: map[string]int{"withdrawer_address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 
 func request_Query_WithdrawerFeeShares_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryWithdrawerFeeSharesRequest
@@ -248,7 +236,6 @@ func request_Query_WithdrawerFeeShares_0(ctx context.Context, marshaler runtime.
 
 	msg, err := client.WithdrawerFeeShares(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_WithdrawerFeeShares_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -282,7 +269,6 @@ func local_request_Query_WithdrawerFeeShares_0(ctx context.Context, marshaler ru
 
 	msg, err := server.WithdrawerFeeShares(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
@@ -290,7 +276,6 @@ func local_request_Query_WithdrawerFeeShares_0(ctx context.Context, marshaler ru
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
 // Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterQueryHandlerFromEndpoint instead.
 func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, server QueryServer) error {
-
 	mux.Handle("GET", pattern_Query_FeeShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -311,7 +296,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_FeeShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_FeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -334,7 +318,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_FeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_Params_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -357,7 +340,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_Params_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_DeployerFeeShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -380,7 +362,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_DeployerFeeShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_WithdrawerFeeShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -403,7 +384,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_WithdrawerFeeShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	return nil
@@ -446,7 +426,6 @@ func RegisterQueryHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "QueryClient" to call the correct interceptors.
 func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, client QueryClient) error {
-
 	mux.Handle("GET", pattern_Query_FeeShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -464,7 +443,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_FeeShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_FeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -484,7 +462,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_FeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_Params_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -504,7 +481,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_Params_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_DeployerFeeShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -524,7 +500,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_DeployerFeeShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_WithdrawerFeeShares_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -544,7 +519,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_WithdrawerFeeShares_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	return nil

--- a/x/feeshare/types/tx.pb.go
+++ b/x/feeshare/types/tx.pb.go
@@ -6,6 +6,10 @@ package types
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/gogo/protobuf/grpc"
 	proto "github.com/gogo/protobuf/proto"
@@ -13,15 +17,14 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	io "io"
-	math "math"
-	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -47,9 +50,11 @@ func (*MsgRegisterFeeShare) ProtoMessage()    {}
 func (*MsgRegisterFeeShare) Descriptor() ([]byte, []int) {
 	return fileDescriptor_84f7f11948541b86, []int{0}
 }
+
 func (m *MsgRegisterFeeShare) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgRegisterFeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgRegisterFeeShare.Marshal(b, m, deterministic)
@@ -62,12 +67,15 @@ func (m *MsgRegisterFeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
+
 func (m *MsgRegisterFeeShare) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgRegisterFeeShare.Merge(m, src)
 }
+
 func (m *MsgRegisterFeeShare) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgRegisterFeeShare) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgRegisterFeeShare.DiscardUnknown(m)
 }
@@ -96,8 +104,7 @@ func (m *MsgRegisterFeeShare) GetWithdrawerAddress() string {
 }
 
 // MsgRegisterFeeShareResponse defines the MsgRegisterFeeShare response type
-type MsgRegisterFeeShareResponse struct {
-}
+type MsgRegisterFeeShareResponse struct{}
 
 func (m *MsgRegisterFeeShareResponse) Reset()         { *m = MsgRegisterFeeShareResponse{} }
 func (m *MsgRegisterFeeShareResponse) String() string { return proto.CompactTextString(m) }
@@ -105,9 +112,11 @@ func (*MsgRegisterFeeShareResponse) ProtoMessage()    {}
 func (*MsgRegisterFeeShareResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_84f7f11948541b86, []int{1}
 }
+
 func (m *MsgRegisterFeeShareResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgRegisterFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgRegisterFeeShareResponse.Marshal(b, m, deterministic)
@@ -120,12 +129,15 @@ func (m *MsgRegisterFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) 
 		return b[:n], nil
 	}
 }
+
 func (m *MsgRegisterFeeShareResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgRegisterFeeShareResponse.Merge(m, src)
 }
+
 func (m *MsgRegisterFeeShareResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgRegisterFeeShareResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgRegisterFeeShareResponse.DiscardUnknown(m)
 }
@@ -151,9 +163,11 @@ func (*MsgUpdateFeeShare) ProtoMessage()    {}
 func (*MsgUpdateFeeShare) Descriptor() ([]byte, []int) {
 	return fileDescriptor_84f7f11948541b86, []int{2}
 }
+
 func (m *MsgUpdateFeeShare) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgUpdateFeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateFeeShare.Marshal(b, m, deterministic)
@@ -166,12 +180,15 @@ func (m *MsgUpdateFeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
+
 func (m *MsgUpdateFeeShare) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateFeeShare.Merge(m, src)
 }
+
 func (m *MsgUpdateFeeShare) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgUpdateFeeShare) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateFeeShare.DiscardUnknown(m)
 }
@@ -200,8 +217,7 @@ func (m *MsgUpdateFeeShare) GetWithdrawerAddress() string {
 }
 
 // MsgUpdateFeeShareResponse defines the MsgUpdateFeeShare response type
-type MsgUpdateFeeShareResponse struct {
-}
+type MsgUpdateFeeShareResponse struct{}
 
 func (m *MsgUpdateFeeShareResponse) Reset()         { *m = MsgUpdateFeeShareResponse{} }
 func (m *MsgUpdateFeeShareResponse) String() string { return proto.CompactTextString(m) }
@@ -209,9 +225,11 @@ func (*MsgUpdateFeeShareResponse) ProtoMessage()    {}
 func (*MsgUpdateFeeShareResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_84f7f11948541b86, []int{3}
 }
+
 func (m *MsgUpdateFeeShareResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgUpdateFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateFeeShareResponse.Marshal(b, m, deterministic)
@@ -224,12 +242,15 @@ func (m *MsgUpdateFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
+
 func (m *MsgUpdateFeeShareResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateFeeShareResponse.Merge(m, src)
 }
+
 func (m *MsgUpdateFeeShareResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgUpdateFeeShareResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateFeeShareResponse.DiscardUnknown(m)
 }
@@ -251,9 +272,11 @@ func (*MsgCancelFeeShare) ProtoMessage()    {}
 func (*MsgCancelFeeShare) Descriptor() ([]byte, []int) {
 	return fileDescriptor_84f7f11948541b86, []int{4}
 }
+
 func (m *MsgCancelFeeShare) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgCancelFeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgCancelFeeShare.Marshal(b, m, deterministic)
@@ -266,12 +289,15 @@ func (m *MsgCancelFeeShare) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
+
 func (m *MsgCancelFeeShare) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgCancelFeeShare.Merge(m, src)
 }
+
 func (m *MsgCancelFeeShare) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgCancelFeeShare) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgCancelFeeShare.DiscardUnknown(m)
 }
@@ -293,8 +319,7 @@ func (m *MsgCancelFeeShare) GetDeployerAddress() string {
 }
 
 // MsgCancelFeeShareResponse defines the MsgCancelFeeShare response type
-type MsgCancelFeeShareResponse struct {
-}
+type MsgCancelFeeShareResponse struct{}
 
 func (m *MsgCancelFeeShareResponse) Reset()         { *m = MsgCancelFeeShareResponse{} }
 func (m *MsgCancelFeeShareResponse) String() string { return proto.CompactTextString(m) }
@@ -302,9 +327,11 @@ func (*MsgCancelFeeShareResponse) ProtoMessage()    {}
 func (*MsgCancelFeeShareResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_84f7f11948541b86, []int{5}
 }
+
 func (m *MsgCancelFeeShareResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgCancelFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgCancelFeeShareResponse.Marshal(b, m, deterministic)
@@ -317,12 +344,15 @@ func (m *MsgCancelFeeShareResponse) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
+
 func (m *MsgCancelFeeShareResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgCancelFeeShareResponse.Merge(m, src)
 }
+
 func (m *MsgCancelFeeShareResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgCancelFeeShareResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgCancelFeeShareResponse.DiscardUnknown(m)
 }
@@ -372,8 +402,10 @@ var fileDescriptor_84f7f11948541b86 = []byte{
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ context.Context
-var _ grpc.ClientConn
+var (
+	_ context.Context
+	_ grpc.ClientConn
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
@@ -439,15 +471,16 @@ type MsgServer interface {
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
-type UnimplementedMsgServer struct {
-}
+type UnimplementedMsgServer struct{}
 
 func (*UnimplementedMsgServer) RegisterFeeShare(ctx context.Context, req *MsgRegisterFeeShare) (*MsgRegisterFeeShareResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RegisterFeeShare not implemented")
 }
+
 func (*UnimplementedMsgServer) UpdateFeeShare(ctx context.Context, req *MsgUpdateFeeShare) (*MsgUpdateFeeShareResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateFeeShare not implemented")
 }
+
 func (*UnimplementedMsgServer) CancelFeeShare(ctx context.Context, req *MsgCancelFeeShare) (*MsgCancelFeeShareResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CancelFeeShare not implemented")
 }
@@ -736,6 +769,7 @@ func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *MsgRegisterFeeShare) Size() (n int) {
 	if m == nil {
 		return 0
@@ -825,9 +859,11 @@ func (m *MsgCancelFeeShareResponse) Size() (n int) {
 func sovTx(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTx(x uint64) (n int) {
 	return sovTx(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *MsgRegisterFeeShare) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -974,6 +1010,7 @@ func (m *MsgRegisterFeeShare) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgRegisterFeeShareResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1024,6 +1061,7 @@ func (m *MsgRegisterFeeShareResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgUpdateFeeShare) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1170,6 +1208,7 @@ func (m *MsgUpdateFeeShare) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgUpdateFeeShareResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1220,6 +1259,7 @@ func (m *MsgUpdateFeeShareResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgCancelFeeShare) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1334,6 +1374,7 @@ func (m *MsgCancelFeeShare) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgCancelFeeShareResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1384,6 +1425,7 @@ func (m *MsgCancelFeeShareResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTx(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/feeshare/types/tx.pb.gw.go
+++ b/x/feeshare/types/tx.pb.gw.go
@@ -25,17 +25,17 @@ import (
 )
 
 // Suppress "imported and not used" errors
-var _ codes.Code
-var _ io.Reader
-var _ status.Status
-var _ = runtime.String
-var _ = utilities.NewDoubleArray
-var _ = descriptor.ForMessage
-var _ = metadata.Join
-
 var (
-	filter_Msg_RegisterFeeShare_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+	_ codes.Code
+	_ io.Reader
+	_ status.Status
+	_ = runtime.String
+	_ = utilities.NewDoubleArray
+	_ = descriptor.ForMessage
+	_ = metadata.Join
 )
+
+var filter_Msg_RegisterFeeShare_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 
 func request_Msg_RegisterFeeShare_0(ctx context.Context, marshaler runtime.Marshaler, client MsgClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq MsgRegisterFeeShare
@@ -50,7 +50,6 @@ func request_Msg_RegisterFeeShare_0(ctx context.Context, marshaler runtime.Marsh
 
 	msg, err := client.RegisterFeeShare(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Msg_RegisterFeeShare_0(ctx context.Context, marshaler runtime.Marshaler, server MsgServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -66,12 +65,9 @@ func local_request_Msg_RegisterFeeShare_0(ctx context.Context, marshaler runtime
 
 	msg, err := server.RegisterFeeShare(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
-var (
-	filter_Msg_UpdateFeeShare_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
-)
+var filter_Msg_UpdateFeeShare_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 
 func request_Msg_UpdateFeeShare_0(ctx context.Context, marshaler runtime.Marshaler, client MsgClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq MsgUpdateFeeShare
@@ -86,7 +82,6 @@ func request_Msg_UpdateFeeShare_0(ctx context.Context, marshaler runtime.Marshal
 
 	msg, err := client.UpdateFeeShare(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Msg_UpdateFeeShare_0(ctx context.Context, marshaler runtime.Marshaler, server MsgServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -102,12 +97,9 @@ func local_request_Msg_UpdateFeeShare_0(ctx context.Context, marshaler runtime.M
 
 	msg, err := server.UpdateFeeShare(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
-var (
-	filter_Msg_CancelFeeShare_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
-)
+var filter_Msg_CancelFeeShare_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 
 func request_Msg_CancelFeeShare_0(ctx context.Context, marshaler runtime.Marshaler, client MsgClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq MsgCancelFeeShare
@@ -122,7 +114,6 @@ func request_Msg_CancelFeeShare_0(ctx context.Context, marshaler runtime.Marshal
 
 	msg, err := client.CancelFeeShare(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Msg_CancelFeeShare_0(ctx context.Context, marshaler runtime.Marshaler, server MsgServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -138,7 +129,6 @@ func local_request_Msg_CancelFeeShare_0(ctx context.Context, marshaler runtime.M
 
 	msg, err := server.CancelFeeShare(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
 // RegisterMsgHandlerServer registers the http handlers for service Msg to "mux".
@@ -146,7 +136,6 @@ func local_request_Msg_CancelFeeShare_0(ctx context.Context, marshaler runtime.M
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
 // Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterMsgHandlerFromEndpoint instead.
 func RegisterMsgHandlerServer(ctx context.Context, mux *runtime.ServeMux, server MsgServer) error {
-
 	mux.Handle("POST", pattern_Msg_RegisterFeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -167,7 +156,6 @@ func RegisterMsgHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 		}
 
 		forward_Msg_RegisterFeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("POST", pattern_Msg_UpdateFeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -190,7 +178,6 @@ func RegisterMsgHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 		}
 
 		forward_Msg_UpdateFeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("POST", pattern_Msg_CancelFeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -213,7 +200,6 @@ func RegisterMsgHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 		}
 
 		forward_Msg_CancelFeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	return nil
@@ -256,7 +242,6 @@ func RegisterMsgHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.C
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "MsgClient" to call the correct interceptors.
 func RegisterMsgHandlerClient(ctx context.Context, mux *runtime.ServeMux, client MsgClient) error {
-
 	mux.Handle("POST", pattern_Msg_RegisterFeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -274,7 +259,6 @@ func RegisterMsgHandlerClient(ctx context.Context, mux *runtime.ServeMux, client
 		}
 
 		forward_Msg_RegisterFeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("POST", pattern_Msg_UpdateFeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -294,7 +278,6 @@ func RegisterMsgHandlerClient(ctx context.Context, mux *runtime.ServeMux, client
 		}
 
 		forward_Msg_UpdateFeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("POST", pattern_Msg_CancelFeeShare_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -314,7 +297,6 @@ func RegisterMsgHandlerClient(ctx context.Context, mux *runtime.ServeMux, client
 		}
 
 		forward_Msg_CancelFeeShare_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	return nil


### PR DESCRIPTION
The stability and/or burn tax are always subtracted from the fee amount of the transaction. When issuing a transaction with `terrad` by providing `--gas auto` then it does not take the gas adjustment into account when calculating the fees from the required gas. This PR fixes odd behavior when gas price settings on the local client are slightly lower than on the chain.
