### PR TITLE
fix missing label in custom/wasm/client

### DIFF
--- a/custom/wasm/client/rest/tx.go
+++ b/custom/wasm/client/rest/tx.go
@@ -28,6 +28,7 @@ type storeCodeReq struct {
 
 type instantiateContractReq struct {
 	BaseReq rest.BaseReq `json:"base_req" yaml:"base_req"`
+	Label   string       `json:"label" yaml:"label"`
 	Deposit sdk.Coins    `json:"deposit" yaml:"deposit"`
 	Admin   string       `json:"admin,omitempty" yaml:"admin"`
 	Msg     []byte       `json:"msg" yaml:"msg"`
@@ -103,6 +104,7 @@ func instantiateContractHandlerFn(cliCtx client.Context) http.HandlerFunc {
 		msg := types.MsgInstantiateContract{
 			Sender: req.BaseReq.From,
 			CodeID: codeID,
+			Label:  req.Label,
 			Funds:  req.Deposit,
 			Msg:    req.Msg,
 			Admin:  req.Admin,

--- a/custom/wasm/module.go
+++ b/custom/wasm/module.go
@@ -12,9 +12,7 @@ import (
 	customrest "github.com/classic-terra/core/v2/custom/wasm/client/rest"
 )
 
-var (
-	_ module.AppModuleBasic = AppModuleBasic{}
-)
+var _ module.AppModuleBasic = AppModuleBasic{}
 
 // AppModuleBasic defines the basic application module used by the wasm module.
 type AppModuleBasic struct {


### PR DESCRIPTION
## Summary of changes

- fix missing label option in `custom/wasm/client/cli/tx.go`
- fix unhandled label in `custom/wasm/client/rest/tx.go
