### PR TITLE
enable swap

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ run:
 linters:
   disable-all: true
   enable:
-    - depguard
     - dogsled
     - exportloopref
     - goconst

--- a/app/app.go
+++ b/app/app.go
@@ -265,7 +265,12 @@ func (app *TerraApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) a
 			app.IBCKeeper.ChannelKeeper.SetChannel(ctx, ibctransfertypes.PortID, channelID, channel)
 		}
 	}
-	if ctx.ChainID() == core.ColumbusChainID && ctx.BlockHeight() == core.SwapEnableForkHeight { // Re-enable IBCs
+	if ctx.ChainID() == core.ColumbusChainID && ctx.BlockHeight() == core.SwapEnableForkHeight { // Re-enable
+		// Enable swap
+		params := app.MarketKeeper.GetParams(ctx)
+		params.MinStabilitySpread = sdk.NewDecWithPrec(1, 2)
+		app.MarketKeeper.SetParams(ctx, params)
+
 		// Enable IBC Channels
 		channelIDs := []string{
 			"channel-1",  // Osmosis

--- a/app/app.go
+++ b/app/app.go
@@ -141,7 +141,6 @@ func NewTerraApp(
 		legacyAmino,
 		maccPerms,
 		allowedReceivingModAcc,
-		app.ModuleAccountAddrs(),
 		skipUpgradeHeights,
 		homePath,
 		invCheckPeriod,

--- a/app/app.go
+++ b/app/app.go
@@ -264,11 +264,7 @@ func (app *TerraApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) a
 			app.IBCKeeper.ChannelKeeper.SetChannel(ctx, ibctransfertypes.PortID, channelID, channel)
 		}
 	}
-	if ctx.ChainID() == core.ColumbusChainID && ctx.BlockHeight() == core.SwapEnableForkHeight { // Re-enable
-		// Enable swap
-		params := app.MarketKeeper.GetParams(ctx)
-		params.MinStabilitySpread = sdk.NewDecWithPrec(1, 2)
-		app.MarketKeeper.SetParams(ctx, params)
+	if ctx.ChainID() == core.ColumbusChainID && ctx.BlockHeight() == core.IBCEnableForkHeight { // Re-enable IBC Channels
 
 		// Enable IBC Channels
 		channelIDs := []string{
@@ -290,6 +286,13 @@ func (app *TerraApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) a
 	// trigger SetModuleVersionMap in upgrade keeper at the VersionMapEnableHeight
 	if ctx.ChainID() == core.ColumbusChainID && ctx.BlockHeight() == core.VersionMapEnableHeight {
 		app.UpgradeKeeper.SetModuleVersionMap(ctx, app.mm.GetVersionMap())
+	}
+
+	if ctx.ChainID() == core.ColumbusChainID && ctx.BlockHeight() == core.JusticeAndTruthHeight { // Re-enable Swaps
+		// Enable swap
+		params := app.MarketKeeper.GetParams(ctx)
+		params.MinStabilitySpread = sdk.NewDecWithPrec(1, 2)
+		app.MarketKeeper.SetParams(ctx, params)
 	}
 
 	return app.mm.BeginBlock(ctx, req)

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -100,7 +100,6 @@ func NewAppKeepers(
 	cdc *codec.LegacyAmino,
 	maccPerms map[string][]string,
 	allowedReceivingModAcc map[string]bool,
-	blockedAddress map[string]bool,
 	skipUpgradeHeights map[int64]bool,
 	homePath string,
 	invCheckPeriod uint,

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
-	simulation2 "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 )
 
@@ -70,7 +69,7 @@ func BenchmarkFullAppSimulation(b *testing.B) {
 		os.Stdout,
 		app.BaseApp,
 		simapp.AppStateFn(app.AppCodec(), app.SimulationManager()),
-		simulation2.RandomAccounts, // Replace with own random account function if using keys other than secp256k1
+		simtypes.RandomAccounts, // Replace with own random account function if using keys other than secp256k1
 		simapp.SimulationOperations(app, app.AppCodec(), config),
 		app.ModuleAccountAddrs(),
 		config,
@@ -138,7 +137,7 @@ func TestAppStateDeterminism(t *testing.T) {
 				os.Stdout,
 				app.BaseApp,
 				AppStateFn(app.AppCodec(), app.SimulationManager()),
-				simulation2.RandomAccounts, // Replace with own random account function if using keys other than secp256k1
+				simtypes.RandomAccounts, // Replace with own random account function if using keys other than secp256k1
 				simapp.SimulationOperations(app, app.AppCodec(), config),
 				app.ModuleAccountAddrs(),
 				config,

--- a/app/testing/test_suite.go
+++ b/app/testing/test_suite.go
@@ -62,7 +62,7 @@ func (s *KeeperTestHelper) Setup() {
 }
 
 // Get implements AppOptions
-func (ao EmptyBaseAppOptions) Get(o string) interface{} {
+func (ao EmptyBaseAppOptions) Get(_ string) interface{} {
 	return nil
 }
 

--- a/app/testing/test_suite.go
+++ b/app/testing/test_suite.go
@@ -47,7 +47,7 @@ type KeeperTestHelper struct {
 	TestAccs    []sdk.AccAddress
 }
 
-func (s *KeeperTestHelper) Setup(t *testing.T) {
+func (s *KeeperTestHelper) Setup() {
 	s.App = SetupApp(s.T())
 	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{Height: 1, ChainID: "doxchain-1", Time: time.Now().UTC()})
 	s.QueryHelper = &baseapp.QueryServiceTestHelper{
@@ -87,7 +87,7 @@ var DefaultConsensusParams = &abci.ConsensusParams{
 
 type EmptyAppOptions struct{}
 
-func (EmptyAppOptions) Get(o string) interface{} { return nil }
+func (EmptyAppOptions) Get(_ string) interface{} { return nil }
 
 func SetupApp(t *testing.T) *app.TerraApp {
 	t.Helper()

--- a/custom/auth/ante/spamming_prevention_test.go
+++ b/custom/auth/ante/spamming_prevention_test.go
@@ -79,7 +79,7 @@ type dummyOracleKeeper struct {
 	feeders map[string]string
 }
 
-func (ok dummyOracleKeeper) ValidateFeeder(ctx sdk.Context, feederAddr sdk.AccAddress, validatorAddr sdk.ValAddress) error {
+func (ok dummyOracleKeeper) ValidateFeeder(_ sdk.Context, feederAddr sdk.AccAddress, validatorAddr sdk.ValAddress) error {
 	if val, ok := ok.feeders[validatorAddr.String()]; ok && val == feederAddr.String() {
 		return nil
 	}

--- a/custom/auth/ante/tax.go
+++ b/custom/auth/ante/tax.go
@@ -53,7 +53,7 @@ func (tfd TaxFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool,
 		// Mempool fee validation
 		// No fee validation for oracle txs
 		if ctx.IsCheckTx() &&
-			!(isOracleTx(ctx, msgs) && gas <= uint64(len(msgs))*MaxOracleMsgGasUsage) {
+			!(isOracleTx(msgs) && gas <= uint64(len(msgs))*MaxOracleMsgGasUsage) {
 			if err := EnsureSufficientMempoolFees(ctx, gas, feeCoins, taxes); err != nil {
 				return ctx, sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, err.Error())
 			}
@@ -201,7 +201,7 @@ func computeTax(ctx sdk.Context, tk TreasuryKeeper, principal sdk.Coins) sdk.Coi
 	return taxes
 }
 
-func isOracleTx(ctx sdk.Context, msgs []sdk.Msg) bool {
+func isOracleTx(msgs []sdk.Msg) bool {
 	for _, msg := range msgs {
 		switch msg.(type) {
 		case *oracleexported.MsgAggregateExchangeRatePrevote:

--- a/custom/wasm/keeper/handler_plugin.go
+++ b/custom/wasm/keeper/handler_plugin.go
@@ -101,7 +101,7 @@ func (h SDKMessageHandler) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddr
 		}
 		events = append(events, sdkEvents...)
 	}
-	return
+	return events, data, nil
 }
 
 func (h SDKMessageHandler) handleSdkMessage(ctx sdk.Context, contractAddr sdk.Address, msg sdk.Msg) (*sdk.Result, error) {

--- a/types/alias.go
+++ b/types/alias.go
@@ -39,8 +39,9 @@ const (
 	ColumbusChainID        = "columbus-5"
 	BombayChainID          = "bombay-12"
 	SwapDisableForkHeight  = fork.SwapDisableForkHeight
-	SwapEnableForkHeight   = fork.SwapEnableForkHeight
+	IBCEnableForkHeight    = fork.IBCEnableForkHeight
 	VersionMapEnableHeight = fork.VersionMapEnableHeight
+	JusticeAndTruthHeight  = fork.JusticeAndTruthHeight
 )
 
 // functions aliases

--- a/types/fork/height.go
+++ b/types/fork/height.go
@@ -2,9 +2,12 @@ package fork
 
 // SwapDisableForkHeight - make min spread to 100% to disable swap
 const (
+	// SwapDisableForkHeight - make min spread to 100% to disable swap, block height is approximately June 1st, 2022.  A highly regrettable decision.
 	SwapDisableForkHeight = 7607790
 	// SwapEnableForkHeight - renable IBC only, block height is approximately December 5th, 2022
-	SwapEnableForkHeight = 10542500
+	IBCEnableForkHeight = 10542500
 	// VersionMapEnableHeight - set the version map to enable software upgrades, approximately February 14, 2023
 	VersionMapEnableHeight = 11543150
+	// JusticeAndTruthHeight - Re-enable swaps, mock Sam Bankman-Fried
+	JusticeAndTruthHeight = 13469420
 )

--- a/types/fork/height.go
+++ b/types/fork/height.go
@@ -8,6 +8,6 @@ const (
 	IBCEnableForkHeight = 10542500
 	// VersionMapEnableHeight - set the version map to enable software upgrades, approximately February 14, 2023
 	VersionMapEnableHeight = 11543150
-	// JusticeAndTruthHeight - Re-enable swaps, mock Sam Bankman-Fried
+	// JusticeAndTruthHeight - Re-enable swaps, mock Sam Bankman-Fried, pursue decentralized money.
 	JusticeAndTruthHeight = 13469420
 )

--- a/wasmbinding/helper.go
+++ b/wasmbinding/helper.go
@@ -4,7 +4,6 @@ import (
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // ConvertProtoToJsonMarshal  unmarshals the given bytes into a proto message and then marshals it to json.
@@ -44,17 +43,4 @@ func ConvertSdkCoinToWasmCoin(coin sdk.Coin) wasmvmtypes.Coin {
 		// Note: gamm tokens have 18 decimal places, so 10^22 is common, no longer in u64 range
 		Amount: coin.Amount.String(),
 	}
-}
-
-// parseAddress parses address from bech32 string and verifies its format.
-func parseAddress(addr string) (sdk.AccAddress, error) {
-	parsed, err := sdk.AccAddressFromBech32(addr)
-	if err != nil {
-		return nil, sdkerrors.Wrap(err, "address from bech32")
-	}
-	err = sdk.VerifyAddressFormat(parsed)
-	if err != nil {
-		return nil, sdkerrors.Wrap(err, "verify address format")
-	}
-	return parsed, nil
 }

--- a/wasmbinding/test/custom_test.go
+++ b/wasmbinding/test/custom_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	TERRA_BINDINGS_DIR           = "../testdata/terra_reflect.wasm"
-	TERRA_RENOVATED_BINDINGS_DIR = "../testdata/old/bindings_tester.wasm"
+	TerraBindingsDir          = "../testdata/terra_reflect.wasm"
+	TerraRenovatedBindingsDir = "../testdata/old/bindings_tester.wasm"
 )
 
 // go test -v -run ^TestWasmTestSuite/TestBindingsAll$ github.com/classic-terra/core/v2/wasmbinding/test
@@ -20,13 +20,13 @@ func (s *WasmTestSuite) TestBindingsAll() {
 	}{
 		{
 			name:        "Terra",
-			dir:         TERRA_BINDINGS_DIR,
+			dir:         TerraBindingsDir,
 			executeFunc: s.executeCustom,
 			queryFunc:   s.queryCustom,
 		},
 		{
 			name:        "Old Terra bindings",
-			dir:         TERRA_RENOVATED_BINDINGS_DIR,
+			dir:         TerraRenovatedBindingsDir,
 			executeFunc: s.executeOldBindings,
 			queryFunc:   s.queryOldBindings,
 		},

--- a/wasmbinding/test/helpers_test.go
+++ b/wasmbinding/test/helpers_test.go
@@ -21,18 +21,18 @@ func TestWasmTestSuite(t *testing.T) {
 }
 
 func (s *WasmTestSuite) SetupTest() {
-	s.Setup(s.T())
+	s.Setup()
 }
 
 func (s *WasmTestSuite) InstantiateContract(addr sdk.AccAddress, contractDir string) sdk.AccAddress {
 	wasmKeeper := s.App.WasmKeeper
 
-	codeId := s.storeReflectCode(addr, contractDir)
+	codeID := s.storeReflectCode(addr, contractDir)
 
-	cInfo := wasmKeeper.GetCodeInfo(s.Ctx, codeId)
+	cInfo := wasmKeeper.GetCodeInfo(s.Ctx, codeID)
 	s.Require().NotNil(cInfo)
 
-	contractAddr := s.instantiateContract(addr, codeId)
+	contractAddr := s.instantiateContract(addr, codeID)
 
 	// check if contract is instantiated
 	info := wasmKeeper.GetContractInfo(s.Ctx, contractAddr)
@@ -45,16 +45,16 @@ func (s *WasmTestSuite) storeReflectCode(addr sdk.AccAddress, contractDir string
 	wasmCode, err := os.ReadFile(contractDir)
 	s.Require().NoError(err)
 
-	codeId, _, err := wasmkeeper.NewDefaultPermissionKeeper(s.App.WasmKeeper).Create(s.Ctx, addr, wasmCode, &wasmtypes.AllowEverybody)
+	codeID, _, err := wasmkeeper.NewDefaultPermissionKeeper(s.App.WasmKeeper).Create(s.Ctx, addr, wasmCode, &wasmtypes.AllowEverybody)
 	s.Require().NoError(err)
 
-	return codeId
+	return codeID
 }
 
-func (s *WasmTestSuite) instantiateContract(funder sdk.AccAddress, codeId uint64) sdk.AccAddress {
+func (s *WasmTestSuite) instantiateContract(funder sdk.AccAddress, codeID uint64) sdk.AccAddress {
 	initMsgBz := []byte("{}")
 	contractKeeper := wasmkeeper.NewDefaultPermissionKeeper(s.App.WasmKeeper)
-	addr, _, err := contractKeeper.Instantiate(s.Ctx, codeId, funder, funder, initMsgBz, "label", nil)
+	addr, _, err := contractKeeper.Instantiate(s.Ctx, codeID, funder, funder, initMsgBz, "label", nil)
 	s.Require().NoError(err)
 
 	return addr

--- a/wasmbinding/test/tax_test.go
+++ b/wasmbinding/test/tax_test.go
@@ -22,7 +22,7 @@ func (s *WasmTestSuite) TestTax() {
 	s.Ctx = s.Ctx.WithBlockHeight(customante.TaxPowerUpgradeHeight + 1)
 
 	// instantiate reflect contract
-	contractAddr := s.InstantiateContract(payer, TERRA_BINDINGS_DIR)
+	contractAddr := s.InstantiateContract(payer, TerraBindingsDir)
 	s.Require().NotEmpty(contractAddr)
 
 	// make a bank send message

--- a/x/market/keeper/querier.go
+++ b/x/market/keeper/querier.go
@@ -25,7 +25,7 @@ func NewQuerier(keeper Keeper) types.QueryServer {
 var _ types.QueryServer = querier{}
 
 // Params queries params of market module
-func (q querier) Params(c context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
+func (q querier) Params(c context.Context, _ *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 	return &types.QueryParamsResponse{Params: q.GetParams(ctx)}, nil
 }
@@ -55,7 +55,7 @@ func (q querier) Swap(c context.Context, req *types.QuerySwapRequest) (*types.Qu
 }
 
 // TerraPoolDelta queries terra pool delta
-func (q querier) TerraPoolDelta(c context.Context, req *types.QueryTerraPoolDeltaRequest) (*types.QueryTerraPoolDeltaResponse, error) {
+func (q querier) TerraPoolDelta(c context.Context, _ *types.QueryTerraPoolDeltaRequest) (*types.QueryTerraPoolDeltaResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 	terraPoolDelta := q.GetTerraPoolDelta(ctx)
 	return &types.QueryTerraPoolDeltaResponse{TerraPoolDelta: terraPoolDelta}, nil

--- a/x/market/keeper/swap.go
+++ b/x/market/keeper/swap.go
@@ -89,7 +89,7 @@ func (k Keeper) ComputeSwap(ctx sdk.Context, offerCoin sdk.Coin, askDenom string
 		}
 
 		spread = tobinTax
-		return
+		return retDecCoin, spread, nil
 	}
 
 	basePool := k.BasePool(ctx)

--- a/x/market/module.go
+++ b/x/market/module.go
@@ -60,7 +60,7 @@ func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 }
 
 // ValidateGenesis performs genesis state validation for the market module.
-func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncodingConfig, bz json.RawMessage) error {
+func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, _ client.TxEncodingConfig, bz json.RawMessage) error {
 	var data types.GenesisState
 	if err := cdc.UnmarshalJSON(bz, &data); err != nil {
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)
@@ -190,7 +190,7 @@ func (am AppModule) ProposalContents(_ module.SimulationState) []simtypes.Weight
 
 // RandomizedParams creates randomized market param changes for the simulator.
 func (AppModule) RandomizedParams(r *rand.Rand) []simtypes.ParamChange {
-	return simulation.ParamChanges(r)
+	return simulation.ParamChanges()
 }
 
 // RegisterStoreDecoder registers a decoder for market module's types

--- a/x/market/simulation/params.go
+++ b/x/market/simulation/params.go
@@ -14,7 +14,7 @@ import (
 
 // ParamChanges defines the parameters that can be modified by param change proposals
 // on the simulation
-func ParamChanges(r *rand.Rand) []simtypes.ParamChange {
+func ParamChanges() []simtypes.ParamChange {
 	return []simtypes.ParamChange{
 		simulation.NewSimParamChange(types.ModuleName, string(types.KeyBasePool),
 			func(r *rand.Rand) string {


### PR DESCRIPTION
## Summary of changes

This PR enables the swap mechanism for Luna classic.  It is untested and comes with no warranty whatsoever. 

I just thought that it would be fun to write. 

Those interested in bringing it back should make a governance proposal specifying a commit that reflects the merge of this PR. 

LUNC has no canonical repository.  The repository does not need to be this one. 

This **is** a political statement.  Good day.

## Notes

* it is set to upgrade at the JusticeAndTruthHeight: 13369420
* iirc somewhere the price of ust is fixed to a dollar, consider changing it to some value below its current market value, but not more than 1/3rd less
* it is probably tempting to make the swap/ust setup more complicated, but I don't recommend that.  
* If validators are feeling rebellious, this doesn't actually need to pass governance.  Just set a height to activate and swap out the binary.  Please note that there was never a gov prop to disable swap.  So it should be enabled no matter what gov says. 
* If validators are not feeling rebellious, then a gov prop could be needed

## Disclaimer

This code could literally kill LUNC the zombie chain or shoot your dog like an american cop.  Notional is leaving the validator set with no intention of ever coming back.  Nonetheless, we truly wish the community well and upon consideration, reenabling the swap mechanism seemed to me to be the most sensible path forward for this chain/community.


## Report of required housekeeping

- [x] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
