### PR TITLE
max supply coin

### DIFF
--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -55119,6 +55119,9 @@ definitions:
       min_stability_spread:
         type: string
         format: byte
+      max_supply_coin:
+        type: string
+        format: byte
     description: Params defines the parameters for the market module.
   terra.market.v1beta1.QueryParamsResponse:
     type: object

--- a/proto/terra/market/v1beta1/market.proto
+++ b/proto/terra/market/v1beta1/market.proto
@@ -21,4 +21,9 @@ message Params {
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
     (gogoproto.nullable)   = false
   ];
+  bytes  max_supply_coin = 3 [
+    (gogoproto.moretags)   = "yaml:\"max_supply_coin\"",
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Coin",
+    (gogoproto.nullable)   = false
+  ];
 }

--- a/x/market/keeper/params.go
+++ b/x/market/keeper/params.go
@@ -25,6 +25,15 @@ func (k Keeper) PoolRecoveryPeriod(ctx sdk.Context) (res uint64) {
 	return
 }
 
+func (k Keeper) GetMaxSupplyCoin(ctx sdk.Context) (res []sdk.Coin) {
+	k.paramSpace.Get(ctx, types.KeyMaxSupplyCoin, &res)
+	return
+}
+
+func (k Keeper) SetMaxSupplyCoin(ctx sdk.Context, maxSupplyCoin []sdk.Coin) {
+	k.paramSpace.Set(ctx, types.KeyMaxSupplyCoin, maxSupplyCoin)
+}
+
 // GetParams returns the total set of market parameters.
 func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
 	k.paramSpace.GetParamSet(ctx, &params)

--- a/x/market/keeper/swap_test.go
+++ b/x/market/keeper/swap_test.go
@@ -75,13 +75,13 @@ func TestComputeInternalSwap(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		offerCoin := sdk.NewDecCoin(core.MicroSDRDenom, lunaPriceInSDR.MulInt64(rand.Int63()+1).TruncateInt())
-		retCoin, err := input.MarketKeeper.ComputeInternalSwap(input.Ctx, offerCoin, core.MicroLunaDenom)
+		retCoin, err := input.MarketKeeper.ComputeInternalSwap(input.Ctx, offerCoin, core.MicroLunaDenom, false)
 		require.NoError(t, err)
 		require.Equal(t, offerCoin.Amount.Quo(lunaPriceInSDR), retCoin.Amount)
 	}
 
 	offerCoin := sdk.NewDecCoin(core.MicroSDRDenom, lunaPriceInSDR.QuoInt64(2).TruncateInt())
-	_, err := input.MarketKeeper.ComputeInternalSwap(input.Ctx, offerCoin, core.MicroLunaDenom)
+	_, err := input.MarketKeeper.ComputeInternalSwap(input.Ctx, offerCoin, core.MicroLunaDenom, false)
 	require.Error(t, err)
 }
 

--- a/x/market/legacy/v04/types.go
+++ b/x/market/legacy/v04/types.go
@@ -13,9 +13,10 @@ const (
 type (
 	// Params market parameters
 	Params struct {
-		BasePool           sdk.Dec `json:"base_pool" yaml:"base_pool"`
-		PoolRecoveryPeriod int64   `json:"pool_recovery_period" yaml:"pool_recovery_period"`
-		MinStabilitySpread sdk.Dec `json:"min_spread" yaml:"min_spread"`
+		BasePool           sdk.Dec    `json:"base_pool" yaml:"base_pool"`
+		PoolRecoveryPeriod int64      `json:"pool_recovery_period" yaml:"pool_recovery_period"`
+		MinStabilitySpread sdk.Dec    `json:"min_spread" yaml:"min_spread"`
+		MaxSupplyCoin      []sdk.Coin `json:"max_supply_coin" yaml:"max_supply_coin"`
 	}
 
 	// GenesisState is the struct representation of the export genesis

--- a/x/market/legacy/v05/migrate.go
+++ b/x/market/legacy/v05/migrate.go
@@ -15,12 +15,14 @@ import (
 func Migrate(
 	marketGenState v04market.GenesisState,
 ) *v05market.GenesisState {
+
 	return &v05market.GenesisState{
 		TerraPoolDelta: sdk.ZeroDec(),
 		Params: v05market.Params{
 			BasePool:           marketGenState.Params.BasePool,
 			PoolRecoveryPeriod: uint64(marketGenState.Params.PoolRecoveryPeriod),
 			MinStabilitySpread: marketGenState.Params.MinStabilitySpread,
+			MaxSupplyCoin:      marketGenState.Params.MaxSupplyCoin,
 		},
 	}
 }

--- a/x/market/legacy/v05/migrate_test.go
+++ b/x/market/legacy/v05/migrate_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestMigrate(t *testing.T) {
+
 	sdk.GetConfig().SetBech32PrefixForAccount(core.Bech32PrefixAccAddr, core.Bech32PrefixAccPub)
 
 	encodingConfig := app.MakeEncodingConfig()
@@ -32,6 +33,29 @@ func TestMigrate(t *testing.T) {
 			BasePool:           sdk.NewDec(1000000),
 			PoolRecoveryPeriod: int64(10000),
 			MinStabilitySpread: sdk.NewDecWithPrec(2, 2),
+			MaxSupplyCoin: []sdk.Coin{
+				{Denom: "uluna", Amount: sdk.NewInt(10000000000)},
+				{Denom: "usdr", Amount: sdk.NewInt(500000000)},
+				{Denom: "uusd", Amount: sdk.NewInt(500000000)},
+				{Denom: "ukrw", Amount: sdk.NewInt(500000000)},
+				{Denom: "umnt", Amount: sdk.NewInt(500000000)},
+				{Denom: "ueur", Amount: sdk.NewInt(500000000)},
+				{Denom: "ucny", Amount: sdk.NewInt(500000000)},
+				{Denom: "ujpy", Amount: sdk.NewInt(500000000)},
+				{Denom: "ugbp", Amount: sdk.NewInt(500000000)},
+				{Denom: "uinr", Amount: sdk.NewInt(500000000)},
+				{Denom: "ucad", Amount: sdk.NewInt(500000000)},
+				{Denom: "uchf", Amount: sdk.NewInt(500000000)},
+				{Denom: "uaud", Amount: sdk.NewInt(500000000)},
+				{Denom: "usgd", Amount: sdk.NewInt(500000000)},
+				{Denom: "uthb", Amount: sdk.NewInt(500000000)},
+				{Denom: "usek", Amount: sdk.NewInt(500000000)},
+				{Denom: "unok", Amount: sdk.NewInt(500000000)},
+				{Denom: "udkk", Amount: sdk.NewInt(500000000)},
+				{Denom: "uidr", Amount: sdk.NewInt(500000000)},
+				{Denom: "uphp", Amount: sdk.NewInt(500000000)},
+				//{Denom: "uhkd", Amount: sdk.NewInt(500000000)},
+			},
 		},
 	}
 
@@ -50,13 +74,95 @@ func TestMigrate(t *testing.T) {
 	// Make sure about:
 	// - BasePool to Mint & Burn pool
 	expected := `{
-	"params": {
-		"base_pool": "1000000.000000000000000000",
-		"min_stability_spread": "0.020000000000000000",
-		"pool_recovery_period": "10000"
-	},
-	"terra_pool_delta": "0.000000000000000000"
-}`
+		"params": {
+		  "base_pool": "1000000.000000000000000000",
+		  "min_stability_spread": "0.020000000000000000",
+		  "pool_recovery_period": "10000",
+		  "max_supply_coin": [
+			{
+			  "Denom": "uluna",
+			  "Amount": "10000000000"
+			},
+			{
+			  "Denom": "usdr",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "uusd",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "ukrw",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "umnt",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "ueur",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "ucny",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "ujpy",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "ugbp",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "uinr",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "ucad",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "uchf",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "uaud",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "usgd",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "uthb",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "usek",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "unok",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "udkk",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "uidr",
+			  "Amount": "500000000"
+			},
+			{
+			  "Denom": "uphp",
+			  "Amount": "500000000"
+			}
+		  ]
+		},
+		"terra_pool_delta": "0.000000000000000000"
+	  }`
 
 	assert.JSONEq(t, expected, string(indentedBz))
 }

--- a/x/market/types/expected_keepers.go
+++ b/x/market/types/expected_keepers.go
@@ -17,7 +17,7 @@ type BankKeeper interface {
 	SendCoinsFromModuleToModule(ctx sdk.Context, senderModule string, recipientModule string, amt sdk.Coins) error
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
-
+	GetSupply(ctx sdk.Context, denom string) sdk.Coin
 	BurnCoins(ctx sdk.Context, name string, amt sdk.Coins) error
 	MintCoins(ctx sdk.Context, name string, amt sdk.Coins) error
 

--- a/x/market/types/market.pb.go
+++ b/x/market/types/market.pb.go
@@ -12,6 +12,7 @@ import (
 	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
+	
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -32,7 +33,9 @@ type Params struct {
 	BasePool           github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,1,opt,name=base_pool,json=basePool,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"base_pool" yaml:"base_pool"`
 	PoolRecoveryPeriod uint64                                 `protobuf:"varint,2,opt,name=pool_recovery_period,json=poolRecoveryPeriod,proto3" json:"pool_recovery_period,omitempty" yaml:"pool_recovery_period"`
 	MinStabilitySpread github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,3,opt,name=min_stability_spread,json=minStabilitySpread,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"min_stability_spread" yaml:"min_stability_spread"`
+    MaxSupplyCoin   []github_com_cosmos_cosmos_sdk_types.Coin  `protobuf:"bytes,4,opt,name=max_supply_coin,json=maxSupplyCoin,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Coin" json:"max_supply_coin" yaml:"max_supply_coin"`
 }
+
 
 func (m *Params) Reset()      { *m = Params{} }
 func (*Params) ProtoMessage() {}
@@ -137,9 +140,22 @@ func (this *Params) Equal(that interface{}) bool {
 	if !this.MinStabilitySpread.Equal(that1.MinStabilitySpread) {
 		return false
 	}
+	// if !this.MaxSupplyCoin.Equal(that1.MaxSupplyCoin) {
+	// 	return false
+	// }
+	// result := isExists(id, products)
 	return true
 }
-
+// func isExists(id github_com_cosmos_cosmos_sdk_types.Coin, coins []github_com_cosmos_cosmos_sdk_types.Coin) (result bool) {
+// 	result = false
+// 	for _, coin := range coins {
+// 		if coin.Id == id {
+// 			result = true
+// 			break
+// 		}
+// 	}
+// 	return result
+// }
 func (m *Params) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -170,6 +186,7 @@ func (m *Params) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	i--
 	dAtA[i] = 0x1a
+	
 	if m.PoolRecoveryPeriod != 0 {
 		i = encodeVarintMarket(dAtA, i, uint64(m.PoolRecoveryPeriod))
 		i--

--- a/x/market/types/params.go
+++ b/x/market/types/params.go
@@ -19,13 +19,37 @@ var (
 	KeyPoolRecoveryPeriod = []byte("PoolRecoveryPeriod")
 	// Min spread
 	KeyMinStabilitySpread = []byte("MinStabilitySpread")
+	KeyMaxSupplyCoin      = []byte("MaxSupplyCoin")
 )
 
 // Default parameter values
 var (
 	DefaultBasePool           = sdk.NewDec(1000000 * core.MicroUnit) // 1000,000sdr = 1000,000,000,000usdr
 	DefaultPoolRecoveryPeriod = core.BlocksPerDay                    // 14,400
-	DefaultMinStabilitySpread = sdk.NewDecWithPrec(2, 2)             // 2%
+	DefaultMinStabilitySpread = sdk.NewDecWithPrec(2, 2)
+	DefaultMaxSupplyCoin      = []sdk.Coin{
+		{Denom: "uluna", Amount: sdk.NewInt(10000000000)},
+		{Denom: "usdr", Amount: sdk.NewInt(500000000)},
+		{Denom: "uusd", Amount: sdk.NewInt(500000000)},
+		{Denom: "ukrw", Amount: sdk.NewInt(500000000)},
+		{Denom: "umnt", Amount: sdk.NewInt(500000000)},
+		{Denom: "ueur", Amount: sdk.NewInt(500000000)},
+		{Denom: "ucny", Amount: sdk.NewInt(500000000)},
+		{Denom: "ujpy", Amount: sdk.NewInt(500000000)},
+		{Denom: "ugbp", Amount: sdk.NewInt(500000000)},
+		{Denom: "uinr", Amount: sdk.NewInt(500000000)},
+		{Denom: "ucad", Amount: sdk.NewInt(500000000)},
+		{Denom: "uchf", Amount: sdk.NewInt(500000000)},
+		{Denom: "uaud", Amount: sdk.NewInt(500000000)},
+		{Denom: "usgd", Amount: sdk.NewInt(500000000)},
+		{Denom: "uthb", Amount: sdk.NewInt(500000000)},
+		{Denom: "usek", Amount: sdk.NewInt(500000000)},
+		{Denom: "unok", Amount: sdk.NewInt(500000000)},
+		{Denom: "udkk", Amount: sdk.NewInt(500000000)},
+		{Denom: "uidr", Amount: sdk.NewInt(500000000)},
+		{Denom: "uphp", Amount: sdk.NewInt(500000000)},
+		//{Denom: "uhkd", Amount: sdk.NewInt(500000000)},
+	}
 )
 
 var _ paramstypes.ParamSet = &Params{}
@@ -36,6 +60,7 @@ func DefaultParams() Params {
 		BasePool:           DefaultBasePool,
 		PoolRecoveryPeriod: DefaultPoolRecoveryPeriod,
 		MinStabilitySpread: DefaultMinStabilitySpread,
+		MaxSupplyCoin:      DefaultMaxSupplyCoin,
 	}
 }
 
@@ -57,6 +82,7 @@ func (p *Params) ParamSetPairs() paramstypes.ParamSetPairs {
 		paramstypes.NewParamSetPair(KeyBasePool, &p.BasePool, validateBasePool),
 		paramstypes.NewParamSetPair(KeyPoolRecoveryPeriod, &p.PoolRecoveryPeriod, validatePoolRecoveryPeriod),
 		paramstypes.NewParamSetPair(KeyMinStabilitySpread, &p.MinStabilitySpread, validateMinStabilitySpread),
+		paramstypes.NewParamSetPair(KeyMaxSupplyCoin, &p.MaxSupplyCoin, validateMaxSupplyCoin),
 	}
 }
 
@@ -71,7 +97,9 @@ func (p Params) Validate() error {
 	if p.MinStabilitySpread.IsNegative() || p.MinStabilitySpread.GT(sdk.OneDec()) {
 		return fmt.Errorf("market minimum stability spead should be a value between [0,1], is %s", p.MinStabilitySpread)
 	}
-
+	if len(p.MaxSupplyCoin) == 0 {
+		return fmt.Errorf("max supplay cannot be empty %s", p.MaxSupplyCoin)
+	}
 	return nil
 }
 
@@ -114,6 +142,18 @@ func validateMinStabilitySpread(i interface{}) error {
 	if v.GT(sdk.OneDec()) {
 		return fmt.Errorf("min spread is too large: %s", v)
 	}
+
+	return nil
+}
+func validateMaxSupplyCoin(i interface{}) error {
+	_, ok := i.([]sdk.Coin)
+	if !ok {
+		return fmt.Errorf("invalid parameter type: %T", i)
+	}
+
+	// if v[0].IsNegative() {
+	// 	return fmt.Errorf("min spread must be positive or zero: %s", v)
+	// }
 
 	return nil
 }

--- a/x/treasury/keeper/indicator.go
+++ b/x/treasury/keeper/indicator.go
@@ -26,7 +26,7 @@ func (k Keeper) alignCoins(ctx sdk.Context, coins sdk.DecCoins, denom string) (a
 	alignedAmt = sdk.ZeroDec()
 	for _, coinReward := range coins {
 		if coinReward.Denom != denom {
-			swappedReward, err := k.marketKeeper.ComputeInternalSwap(ctx, coinReward, denom)
+			swappedReward, err := k.marketKeeper.ComputeInternalSwap(ctx, coinReward, denom, false)
 			if err != nil {
 				continue
 			}

--- a/x/treasury/keeper/policy.go
+++ b/x/treasury/keeper/policy.go
@@ -16,7 +16,7 @@ func (k Keeper) UpdateTaxCap(ctx sdk.Context) sdk.Coins {
 			continue
 		}
 
-		newDecCap, err := k.marketKeeper.ComputeInternalSwap(ctx, taxPolicyCap, denom.Name)
+		newDecCap, err := k.marketKeeper.ComputeInternalSwap(ctx, taxPolicyCap, denom.Name, false)
 		if err == nil {
 			newCap, _ := newDecCap.TruncateDecimal()
 			newCaps = append(newCaps, newCap)

--- a/x/treasury/types/exptected_keepers.go
+++ b/x/treasury/types/exptected_keepers.go
@@ -25,7 +25,7 @@ type BankKeeper interface {
 
 // MarketKeeper expected market keeper
 type MarketKeeper interface {
-	ComputeInternalSwap(ctx sdk.Context, offerCoin sdk.DecCoin, askDenom string) (sdk.DecCoin, error)
+	ComputeInternalSwap(ctx sdk.Context, offerCoin sdk.DecCoin, askDenom string, notCheckSupply bool) (sdk.DecCoin, error)
 }
 
 // StakingKeeper expected keeper for staking module


### PR DESCRIPTION
## Summary of changes

I am sending coding to limit supplay of all currencies(uluna, uusd, usdr, ukrw, umnt, ueur, ucny, ujpy, ugbp, uinr, ucad, uchf, uaud, usgd, uthb, usek, unok, udkk, uidr , uphp, uhkd), this avoids going over the coinage value. When placing 10 Billion in uluna and 500 Million in usdr, the buyer will not be able to make the exchange example: ukrw=> uluna or ukrw=>uusd, however the others will be able to make the exchange as uluna => ukrw or usdr=> ukrw. With that LUNC or USTC will be burned and ukrw will be coined. The idea is to release the markt swap, because if you create pairs like ukrw =>alxUSDC, we could circulate the money in $ burning the minted coins and only the fees will be deducted.

I am already developing a protocol and as soon as it is ready I will put it to the governance to vote, which is as follows: automatic burns via the system and draining all the supply from other CEXs and bringing it to the blockchain. Explain this further on.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
