### PR TITLE
feat: exempt ibc denoms from tax

### DIFF
--- a/types/alias.go
+++ b/types/alias.go
@@ -36,6 +36,7 @@ const (
 	Bech32PrefixConsPub  = util.Bech32PrefixConsPub
 	ColumbusChainID      = "columbus-5"
 	BombayChainID        = "bombay-12"
+	OsmoIbcDenom         = "ibc/0ef15df2f02480ade0bb6e85d9ebb5daea2836d3860e9f97f9aade4f57a31aa0"
 )
 
 // functions aliases


### PR DESCRIPTION
Dear L1 Task Force,

I hereby humbly ask you to accept these code changes. This pull request will exempt ibc denoms from on chain (burn) taxes. This is a feature that passed governance approval back in January and slipped because the original implementation from me was merged into old frozen main. The approved on-chain proposal can be found [here](https://station.terraclassic.community/proposal/columbus-5/11267)

Changes include:

- Implemention of the the exemption logic in the ante handler
- Implementation of a Test that would fail if the exemption was not present

Thank you for considering this PR. Your ongoing work and engagement for this Blockchain is very much appreciated.

Best,
Till
