### PR TITLE
fix: ante handler shall not panic

### DIFF
--- a/custom/auth/ante/tax.go
+++ b/custom/auth/ante/tax.go
@@ -154,11 +154,9 @@ func FilterMsgAndComputeTax(ctx sdk.Context, tk TreasuryKeeper, msgs ...sdk.Msg)
 
 		case *authz.MsgExec:
 			messages, err := msg.GetMessages()
-			if err != nil {
-				panic(err)
+			if err == nil {
+				taxes = taxes.Add(FilterMsgAndComputeTax(ctx, tk, messages...)...)
 			}
-
-			taxes = taxes.Add(FilterMsgAndComputeTax(ctx, tk, messages...)...)
 		}
 	}
 


### PR DESCRIPTION

Dear L1 Team. I humbly ask you to accept the following code changes to fix misbehavior of the terrad client software: The `FilterMsgAndComputeTax()` function in `tax.go` shall not panic. I changed the logic such that the function returns zero coins if the `GetMsg()` function resulted in an error. Please, have a review. Thank you for hearing me out.

Best,
Till
