### PR TITLE
fix: legacy wasm codec fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ replace (
 	github.com/CosmWasm/wasmd => github.com/classic-terra/wasmd v0.30.0-terra.2
 	github.com/aws/aws-sdk-go v1.25.48 => github.com/aws/aws-sdk-go v1.33.0
 	github.com/aws/aws-sdk-go v1.27.0 => github.com/aws/aws-sdk-go v1.33.0
-	github.com/cosmos/cosmos-sdk => github.com/classic-terra/cosmos-sdk v0.45.14-classic
+	github.com/cosmos/cosmos-sdk => github.com/classic-terra/cosmos-sdk v0.45.14-classic.0.20230901171908-753a3a8938e4
 	github.com/cosmos/ledger-cosmos-go => github.com/terra-money/ledger-terra-go v0.11.2
 	github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf => github.com/docker/docker v1.6.1
 	github.com/ethereum/go-ethereum v1.9.25 => github.com/ethereum/go-ethereum v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
-github.com/classic-terra/cosmos-sdk v0.45.14-classic h1:R3WBEoqnBDGef3LCCq0uTWEqFO8pwwqkIv3nQWv5Z+E=
-github.com/classic-terra/cosmos-sdk v0.45.14-classic/go.mod h1:KaUwQKijD7mOiKnPa/7JOJoGfDt4Mq+1CGlODMHPmfM=
+github.com/classic-terra/cosmos-sdk v0.45.14-classic.0.20230901171908-753a3a8938e4 h1:pjU3Q6+Wlhm7S61r18deqb/yhYRbu31VhmBcgnBIWNU=
+github.com/classic-terra/cosmos-sdk v0.45.14-classic.0.20230901171908-753a3a8938e4/go.mod h1:KaUwQKijD7mOiKnPa/7JOJoGfDt4Mq+1CGlODMHPmfM=
 github.com/classic-terra/tendermint v0.34.24-terra.0 h1:ZGaJpmKfxjlmmLO80t03jlK2SBQfJKlLsF+ItDbXtko=
 github.com/classic-terra/tendermint v0.34.24-terra.0/go.mod h1:rXVrl4OYzmIa1I91av3iLv2HS0fGSiucyW9J4aMTpKI=
 github.com/classic-terra/wasmd v0.30.0-terra.2 h1:qaZx4mloPU6xaJP7TAd3CNzN4iziJ47ClOEkJV5de/Q=


### PR DESCRIPTION
## Description
We have released Terra Classic Core v2.1.2 to fix an error that occurred when querying transactions with legacy wasm codecs (terra.wasm.v1beta1.*) in the past. It was not intended to create new legacy wasm messages in v2.1.x.

However, there was one failed transaction submitted to columbus-5 at height 14354773. This created an AppHash error because v2.1.1 creates raw_log as `unable to resolve type URL /terra.wasm.v1beta1.MsgExecuteContract: tx parse error` with code 2, and v2.1.2 creates raw_log as `failed to execute message; message index: 0: unrecognized wasm message type: *legacy.MsgExecuteContract: unknown request` with code 6.

This PR forces BaseApp.runTx to have the same error as v2.1.1 to avoid AppHash error while keeping the querying legacy wasm codec working.

CosmosSDK PR: https://github.com/classic-terra/cosmos-sdk/pull/11