### PR TITLE
fix: set default `iavl-disable-fastnode` to true

### DIFF
--- a/cmd/terrad/root.go
+++ b/cmd/terrad/root.go
@@ -264,6 +264,8 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, a
 		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),
 		baseapp.SetSnapshot(snapshotStore, snapshotOptions),
 		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get(server.FlagIAVLCacheSize))),
+		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(server.FlagDisableIAVLFastNode))),
+		baseapp.SetIAVLLazyLoading(cast.ToBool(appOpts.Get(server.FlagIAVLLazyLoading))),
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -187,6 +187,6 @@ replace (
 replace (
 	github.com/CosmWasm/wasmd => github.com/classic-terra/wasmd v0.30.0-terra.3
 	github.com/CosmWasm/wasmvm => github.com/classic-terra/wasmvm v1.1.1-terra.1
-	github.com/cosmos/cosmos-sdk => github.com/classic-terra/cosmos-sdk v0.46.14-terra.1
+	github.com/cosmos/cosmos-sdk => github.com/classic-terra/cosmos-sdk v0.46.14-terra.2
 	github.com/cosmos/ledger-cosmos-go => github.com/terra-money/ledger-terra-go v0.11.2
 )

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/classic-terra/cometbft v0.34.29-terra.0 h1:HnRGt7tijI2n5zSVrg/xh1mYYm4Gb4QFlknq+dRP8Jw=
 github.com/classic-terra/cometbft v0.34.29-terra.0/go.mod h1:L9shMfbkZ8B+7JlwANEr+NZbBcn+hBpwdbeYvA5rLCw=
-github.com/classic-terra/cosmos-sdk v0.46.14-terra.1 h1:0sOm4hwot5OCYzt0tlj25fCWmnEFHKh4ph3xRdejLW8=
-github.com/classic-terra/cosmos-sdk v0.46.14-terra.1/go.mod h1:tx+Rr8Fob/HQ8iErtht7Rddu1FrMg2KBQl9anicuxsQ=
+github.com/classic-terra/cosmos-sdk v0.46.14-terra.2 h1:TRuTbrbBMYOFg59G0WHjvIGu9Daf3gO6PoghlLAFQd0=
+github.com/classic-terra/cosmos-sdk v0.46.14-terra.2/go.mod h1:tx+Rr8Fob/HQ8iErtht7Rddu1FrMg2KBQl9anicuxsQ=
 github.com/classic-terra/wasmd v0.30.0-terra.3 h1:qruhiaAIRl14UVtHzfh81pr0YmW94QE4+hqivIi9AYg=
 github.com/classic-terra/wasmd v0.30.0-terra.3/go.mod h1:Ug607EsX+EkW3/xOFaP56kZA7WklN+ZrwUEsaJ22xH0=
 github.com/classic-terra/wasmvm v1.1.1-terra.1 h1:qGozlXFlM/3ossnlABwODJr7bEHUdF/nug8Z3c1Dr84=


### PR DESCRIPTION
## Description
Apply the new classic-terra/cosmos-sdk v0.46.14-terra.2 to set iavl-disable-fastnode to true by default. The iavl-disable-fastnode and iavl-disable-fastnode settings can also be controlled using app.toml.

## Background (Ref: https://github.com/classic-terra/cosmos-sdk/pull/12)
In the past, the value of iavlDisableFastNodeDefault in Terra Classic was set to true, so the IAVL FastNode feature has never been used in Terra Classic. If this value is changed to false, migration will be forced to occur at every node startup.

When testing the migration of Columbus-5, it took approximately 50 minutes on a machine with a 3.6Ghz Intel Core i9 and 128GB of memory.

In addition, the recently discovered bug in IAVL (https://github.com/cosmos/iavl/pull/805) only occurs in nodes using IAVL fast node.
