### PR TITLE
fix: do not BurnTaxSplit when simulating

### DIFF
--- a/custom/auth/ante/fee.go
+++ b/custom/auth/ante/fee.go
@@ -56,7 +56,7 @@ func (fd FeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, nex
 		}
 	}
 
-	if err := fd.checkDeductFee(ctx, feeTx, taxes); err != nil {
+	if err := fd.checkDeductFee(ctx, feeTx, taxes, simulate); err != nil {
 		return ctx, err
 	}
 
@@ -65,7 +65,7 @@ func (fd FeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, nex
 	return next(newCtx, tx, simulate)
 }
 
-func (fd FeeDecorator) checkDeductFee(ctx sdk.Context, feeTx sdk.FeeTx, taxes sdk.Coins) error {
+func (fd FeeDecorator) checkDeductFee(ctx sdk.Context, feeTx sdk.FeeTx, taxes sdk.Coins, simulate bool) error {
 	if addr := fd.accountKeeper.GetModuleAddress(types.FeeCollectorName); addr == nil {
 		return fmt.Errorf("fee collector module account (%s) has not been set", types.FeeCollectorName)
 	}
@@ -102,7 +102,7 @@ func (fd FeeDecorator) checkDeductFee(ctx sdk.Context, feeTx sdk.FeeTx, taxes sd
 			return err
 		}
 
-		if !taxes.IsZero() {
+		if !taxes.IsZero() && !simulate {
 			err := fd.BurnTaxSplit(ctx, taxes)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary of changes

<Describe summary of major changes here>

Closes https://github.com/classic-terra/core/issues/335,

Terra-classic did not BurnTaxSplit in previous versions: https://github.com/classic-terra/core/blob/v2.1.1/custom/auth/ante/burntax.go#L51-L89.

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
