### PR TITLE
fix: set min commission back to 5%

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -52,6 +52,7 @@ import (
 	customauthtx "github.com/classic-terra/core/v2/custom/auth/tx"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
+	"github.com/classic-terra/core/v2/app/upgrades/forks"
 
 	// unnamed import of statik for swagger UI support
 	_ "github.com/classic-terra/core/v2/client/docs/statik"
@@ -67,7 +68,7 @@ var (
 	Upgrades = []upgrades.Upgrade{v2.Upgrade, v3.Upgrade, v4.Upgrade, v5.Upgrade}
 
 	// Forks defines forks to be applied to the network
-	Forks = []upgrades.Fork{}
+	Forks = []upgrades.Fork{forks.FixMinCommissionFork, forks.FixMinCommissionForkRebel}
 )
 
 // Verify app interface at compile time

--- a/app/upgrades/forks/constants.go
+++ b/app/upgrades/forks/constants.go
@@ -22,3 +22,15 @@ var VersionMapEnableFork = upgrades.Fork{
 	UpgradeHeight:  fork.VersionMapEnableHeight,
 	BeginForkLogic: runForkLogicVersionMapEnable,
 }
+
+var FixMinCommissionFork = upgrades.Fork{
+	UpgradeName:    "v2.2.1",
+	UpgradeHeight:  fork.FixMinCommissionHeight,
+	BeginForkLogic: runForkLogicFixMinCommission,
+}
+
+var FixMinCommissionForkRebel = upgrades.Fork{
+	UpgradeName:    "v2.2.1",
+	UpgradeHeight:  fork.FixMinCommissionHeightRebel,
+	BeginForkLogic: runForkLogicFixMinCommissionRebel,
+}

--- a/app/upgrades/forks/forks.go
+++ b/app/upgrades/forks/forks.go
@@ -7,6 +7,8 @@ import (
 	core "github.com/classic-terra/core/v2/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/x/staking/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
 	ibcchanneltypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
 )
@@ -61,4 +63,57 @@ func runForkLogicVersionMapEnable(ctx sdk.Context, keppers *keepers.AppKeepers, 
 	if ctx.ChainID() == core.ColumbusChainID {
 		keppers.UpgradeKeeper.SetModuleVersionMap(ctx, mm.GetVersionMap())
 	}
+}
+
+func forkLogicFixMinCommission(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {
+	var MinCommissionRate = sdk.NewDecWithPrec(5, 2)
+
+	space := keepers.ParamsKeeper.Subspace(stakingtypes.StoreKey)
+	if space.HasKeyTable() {
+		space.Set(ctx, stakingtypes.KeyMinCommissionRate, MinCommissionRate)
+	} else {
+		space.WithKeyTable(types.ParamKeyTable())
+		space.Set(ctx, stakingtypes.KeyMinCommissionRate, MinCommissionRate)
+	}
+
+	keepers.StakingKeeper.IterateValidators(ctx, func(index int64, validator stakingtypes.ValidatorI) (stop bool) {
+		val := validator.(stakingtypes.Validator)
+		rate := val.Commission.Rate
+		maxRate := val.Commission.MaxRate
+
+		if maxRate.LT(MinCommissionRate) {
+			maxRate = MinCommissionRate
+		}
+
+		if rate.LT(MinCommissionRate) {
+			rate = MinCommissionRate
+		}
+
+		val.Commission = stakingtypes.NewCommission(
+			rate,
+			maxRate,
+			val.Commission.MaxChangeRate,
+		)
+
+		keepers.StakingKeeper.SetValidator(ctx, val)
+
+		return false
+
+	})
+
+}
+
+func runForkLogicFixMinCommission(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {
+	if ctx.ChainID() != core.ColumbusChainID {
+		return
+	}
+	runForkLogicFixMinCommission(ctx, keepers, mm)
+
+}
+
+func runForkLogicFixMinCommissionRebel(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {
+	if ctx.ChainID() != core.RebelChainID {
+		return
+	}
+	runForkLogicFixMinCommission(ctx, keepers, mm)
 }

--- a/app/upgrades/forks/forks.go
+++ b/app/upgrades/forks/forks.go
@@ -68,7 +68,11 @@ func runForkLogicVersionMapEnable(ctx sdk.Context, keppers *keepers.AppKeepers, 
 func forkLogicFixMinCommission(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {
 	MinCommissionRate := sdk.NewDecWithPrec(5, 2)
 
-	space := keepers.ParamsKeeper.Subspace(stakingtypes.StoreKey)
+	space, exist := keepers.ParamsKeeper.GetSubspace(stakingtypes.StoreKey)
+	if !exist {
+		panic("staking subspace is not found, breaking the chain anyway so panic")
+	}
+
 	if space.HasKeyTable() {
 		space.Set(ctx, stakingtypes.KeyMinCommissionRate, MinCommissionRate)
 	} else {
@@ -109,7 +113,7 @@ func runForkLogicFixMinCommission(ctx sdk.Context, keepers *keepers.AppKeepers, 
 }
 
 func runForkLogicFixMinCommissionRebel(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {
-	if ctx.ChainID() != core.RebelChainID {
+	if ctx.ChainID() != "localterra" {
 		return
 	}
 	forkLogicFixMinCommission(ctx, keepers, mm)

--- a/app/upgrades/forks/forks.go
+++ b/app/upgrades/forks/forks.go
@@ -66,7 +66,7 @@ func runForkLogicVersionMapEnable(ctx sdk.Context, keppers *keepers.AppKeepers, 
 }
 
 func forkLogicFixMinCommission(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {
-	var MinCommissionRate = sdk.NewDecWithPrec(5, 2)
+	MinCommissionRate := sdk.NewDecWithPrec(5, 2)
 
 	space := keepers.ParamsKeeper.Subspace(stakingtypes.StoreKey)
 	if space.HasKeyTable() {
@@ -98,9 +98,7 @@ func forkLogicFixMinCommission(ctx sdk.Context, keepers *keepers.AppKeepers, mm 
 		keepers.StakingKeeper.SetValidator(ctx, val)
 
 		return false
-
 	})
-
 }
 
 func runForkLogicFixMinCommission(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {
@@ -108,7 +106,6 @@ func runForkLogicFixMinCommission(ctx sdk.Context, keepers *keepers.AppKeepers, 
 		return
 	}
 	runForkLogicFixMinCommission(ctx, keepers, mm)
-
 }
 
 func runForkLogicFixMinCommissionRebel(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {

--- a/app/upgrades/forks/forks.go
+++ b/app/upgrades/forks/forks.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/classic-terra/core/v2/app/keepers"
 	core "github.com/classic-terra/core/v2/types"
+	"github.com/classic-terra/core/v2/x/market/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/staking/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
 	ibcchanneltypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
@@ -105,12 +105,12 @@ func runForkLogicFixMinCommission(ctx sdk.Context, keepers *keepers.AppKeepers, 
 	if ctx.ChainID() != core.ColumbusChainID {
 		return
 	}
-	runForkLogicFixMinCommission(ctx, keepers, mm)
+	forkLogicFixMinCommission(ctx, keepers, mm)
 }
 
 func runForkLogicFixMinCommissionRebel(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {
 	if ctx.ChainID() != core.RebelChainID {
 		return
 	}
-	runForkLogicFixMinCommission(ctx, keepers, mm)
+	forkLogicFixMinCommission(ctx, keepers, mm)
 }

--- a/app/upgrades/forks/forks.go
+++ b/app/upgrades/forks/forks.go
@@ -113,7 +113,7 @@ func runForkLogicFixMinCommission(ctx sdk.Context, keepers *keepers.AppKeepers, 
 }
 
 func runForkLogicFixMinCommissionRebel(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {
-	if ctx.ChainID() != "localterra" {
+	if ctx.ChainID() != core.RebelChainID {
 		return
 	}
 	forkLogicFixMinCommission(ctx, keepers, mm)

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -4,7 +4,7 @@
 FORK=${FORK:-"false"}
 
 # $(curl --silent "https://api.github.com/repos/classic-terra/core/releases/latest" | jq -r '.tag_name')
-OLD_VERSION=v2.1.2
+OLD_VERSION=v2.2.1
 UPGRADE_WAIT=${UPGRADE_WAIT:-20}
 HOME=mytestnet
 ROOT=$(pwd)

--- a/types/alias.go
+++ b/types/alias.go
@@ -36,6 +36,7 @@ const (
 	Bech32PrefixConsPub  = util.Bech32PrefixConsPub
 	ColumbusChainID      = "columbus-5"
 	BombayChainID        = "bombay-12"
+	RebelChainID         = "rebel-2"
 	OsmoIbcDenom         = "ibc/0ef15df2f02480ade0bb6e85d9ebb5daea2836d3860e9f97f9aade4f57a31aa0"
 )
 

--- a/types/fork/fork.go
+++ b/types/fork/fork.go
@@ -22,5 +22,5 @@ const (
 	VersionMapEnableHeight = int64(11_543_150)
 	// Revert Min Commission slip during v2.2.0 upgrade
 	FixMinCommissionHeight      = int64(14_665_190)
-	FixMinCommissionHeightRebel = int64(14_665_190)
+	FixMinCommissionHeightRebel = int64(16_260_000)
 )

--- a/types/fork/fork.go
+++ b/types/fork/fork.go
@@ -20,4 +20,7 @@ const (
 	// v1.0.5
 	// VersionMapEnableHeight - set the version map to enable software upgrades, approximately February 14, 2023
 	VersionMapEnableHeight = int64(11_543_150)
+	// Revert Min Commission slip during v2.2.0 upgrade
+	FixMinCommissionHeight      = int64(14_665_190)
+	FixMinCommissionHeightRebel = int64(14_665_190)
 )


### PR DESCRIPTION
Dear L1 Team. During the mainnet upgrade the min. validator commission was accidentally set to 0%. This immediately led to creation of 0% validators and also validators lowering their commissions. Simple governance proposal to set the commission to 5% is _not_ sufficient. This is why I prepared this fix to be applied as fork guard or hotfix upgrade (meaning: it's a state machine breaking upgrade, but due to a fork guard validators can install without chain halt).

I suggest to test it on rebel-2 first.

**TODO**: Coordinate/Communication on proper fork block heights.