### PR TITLE
Restrict network in docker-compose.yml to /24

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,4 +134,4 @@ networks:
       driver: default
       config:
       -
-        subnet: 192.168.10.0/16
+        subnet: 192.168.10.0/24


### PR DESCRIPTION
I think using a more restricted network in `docker-compose.yml` makes more sense for us all.

The `/16` network usually fucks the internet connection of my local LAN setup whenever I do `make localnet-start`. So I cannot run the localnet and browse the internet at the same time :D

In turn, the more restricted `/24` network does not collide with most LAN DHHCP setups but contains all the addresses that are used in localterra network setup.

It should be good.
