### PR TITLE
fix: revert v2.2.2 fork logic

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -52,7 +52,6 @@ import (
 	customauthtx "github.com/classic-terra/core/v2/custom/auth/tx"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
-	"github.com/classic-terra/core/v2/app/upgrades/forks"
 
 	// unnamed import of statik for swagger UI support
 	_ "github.com/classic-terra/core/v2/client/docs/statik"
@@ -68,7 +67,7 @@ var (
 	Upgrades = []upgrades.Upgrade{v2.Upgrade, v3.Upgrade, v4.Upgrade, v5.Upgrade}
 
 	// Forks defines forks to be applied to the network
-	Forks = []upgrades.Fork{forks.FixMinCommissionFork, forks.FixMinCommissionForkRebel}
+	Forks = []upgrades.Fork{}
 )
 
 // Verify app interface at compile time

--- a/app/upgrades/forks/constants.go
+++ b/app/upgrades/forks/constants.go
@@ -22,15 +22,3 @@ var VersionMapEnableFork = upgrades.Fork{
 	UpgradeHeight:  fork.VersionMapEnableHeight,
 	BeginForkLogic: runForkLogicVersionMapEnable,
 }
-
-var FixMinCommissionFork = upgrades.Fork{
-	UpgradeName:    "v2.2.1",
-	UpgradeHeight:  fork.FixMinCommissionHeight,
-	BeginForkLogic: runForkLogicFixMinCommission,
-}
-
-var FixMinCommissionForkRebel = upgrades.Fork{
-	UpgradeName:    "v2.2.1",
-	UpgradeHeight:  fork.FixMinCommissionHeightRebel,
-	BeginForkLogic: runForkLogicFixMinCommissionRebel,
-}


### PR DESCRIPTION
Fork logic is deprecated and was never applied to the main network.