### PR TITLE
feat: 800M ustc blacklist softfork

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -198,6 +198,7 @@ func NewTerraApp(
 
 	anteHandler, err := customante.NewAnteHandler(
 		customante.HandlerOptions{
+			Cdc:                app.appCodec,
 			AccountKeeper:      app.AccountKeeper,
 			BankKeeper:         app.BankKeeper,
 			FeegrantKeeper:     app.FeeGrantKeeper,

--- a/app/app.go
+++ b/app/app.go
@@ -43,6 +43,7 @@ import (
 
 	// upgrades
 	"github.com/classic-terra/core/v2/app/upgrades"
+	fork "github.com/classic-terra/core/v2/app/upgrades/forks"
 	v2 "github.com/classic-terra/core/v2/app/upgrades/v2"
 	v3 "github.com/classic-terra/core/v2/app/upgrades/v3"
 	v4 "github.com/classic-terra/core/v2/app/upgrades/v4"
@@ -67,7 +68,7 @@ var (
 	Upgrades = []upgrades.Upgrade{v2.Upgrade, v3.Upgrade, v4.Upgrade, v5.Upgrade}
 
 	// Forks defines forks to be applied to the network
-	Forks = []upgrades.Fork{}
+	Forks = []upgrades.Fork{fork.Freeze800MFork, fork.Freeze800MForkRebel}
 )
 
 // Verify app interface at compile time

--- a/app/app.go
+++ b/app/app.go
@@ -211,6 +211,7 @@ func NewTerraApp(
 			GovKeeper:          app.GovKeeper,
 			WasmConfig:         &wasmConfig,
 			TXCounterStoreKey:  app.GetKey(wasm.StoreKey),
+			HostKeeper:         app.ICAHostKeeper,
 		},
 	)
 	if err != nil {

--- a/app/upgrades/forks/constants.go
+++ b/app/upgrades/forks/constants.go
@@ -22,3 +22,15 @@ var VersionMapEnableFork = upgrades.Fork{
 	UpgradeHeight:  fork.VersionMapEnableHeight,
 	BeginForkLogic: runForkLogicVersionMapEnable,
 }
+
+var Freeze800MFork = upgrades.Fork{
+	UpgradeName:    "v2.2.3",
+	UpgradeHeight:  fork.Freeze800MHeight,
+	BeginForkLogic: runForkLogicBlacklist800M,
+}
+
+var Freeze800MForkRebel = upgrades.Fork{
+	UpgradeName:    "v2.2.3",
+	UpgradeHeight:  fork.Freeze800MHeightRebel,
+	BeginForkLogic: runForkLogicBlacklist800MRebel,
+}

--- a/app/upgrades/forks/forks.go
+++ b/app/upgrades/forks/forks.go
@@ -65,7 +65,6 @@ func runForkLogicVersionMapEnable(ctx sdk.Context, keppers *keepers.AppKeepers, 
 }
 
 func runForkLogicBlacklist800M(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {
-
 	var freeze treasurytypes.FreezeList
 
 	if ctx.ChainID() == core.ColumbusChainID {
@@ -80,11 +79,9 @@ func runForkLogicBlacklist800M(ctx sdk.Context, keepers *keepers.AppKeepers, mm 
 		keepers.TreasuryKeeper.SetFreezeAddrs(ctx, freeze)
 
 	}
-
 }
 
 func runForkLogicBlacklist800MRebel(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {
-
 	var freeze treasurytypes.FreezeList
 
 	if ctx.ChainID() == core.RebelChainID {

--- a/app/upgrades/forks/forks.go
+++ b/app/upgrades/forks/forks.go
@@ -75,7 +75,7 @@ func runForkLogicBlacklist800M(ctx sdk.Context, keepers *keepers.AppKeepers, mm 
 			ctx.Logger().Error("Could not unmarshal blacklist address - ignoring.")
 			return
 		}
-		freeze.Add(addr)
+		freeze.Add(addr.String())
 
 		keepers.TreasuryKeeper.SetFreezeAddrs(ctx, freeze)
 
@@ -94,14 +94,14 @@ func runForkLogicBlacklist800MRebel(ctx sdk.Context, keepers *keepers.AppKeepers
 			ctx.Logger().Error("Could not unmarshal blacklist address - ignoring.")
 			return
 		}
-		freeze.Add(addr)
+		freeze.Add(addr.String())
 
 		addr, err = sdk.AccAddressFromBech32("terra1njlydj87f05jmzdt9wmam0z28dlrc97qr6twqn")
 		if err != nil {
 			ctx.Logger().Error("Could not unmarshal blacklist address - ignoring.")
 			return
 		}
-		freeze.Add(addr)
+		freeze.Add(addr.String())
 
 		keepers.TreasuryKeeper.SetFreezeAddrs(ctx, freeze)
 

--- a/app/upgrades/forks/forks.go
+++ b/app/upgrades/forks/forks.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/classic-terra/core/v2/app/keepers"
 	core "github.com/classic-terra/core/v2/types"
+	treasurytypes "github.com/classic-terra/core/v2/x/treasury/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	ibctransfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
@@ -60,5 +61,49 @@ func runForkLogicVersionMapEnable(ctx sdk.Context, keppers *keepers.AppKeepers, 
 	// trigger SetModuleVersionMap in upgrade keeper at the VersionMapEnableHeight
 	if ctx.ChainID() == core.ColumbusChainID {
 		keppers.UpgradeKeeper.SetModuleVersionMap(ctx, mm.GetVersionMap())
+	}
+}
+
+func runForkLogicBlacklist800M(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {
+
+	var freeze treasurytypes.FreezeList
+
+	if ctx.ChainID() == core.ColumbusChainID {
+
+		addr, err := sdk.AccAddressFromBech32("terra1qyw695vaxj7jl6s4u564c6xkfe59kercg0h88w")
+		if err != nil {
+			ctx.Logger().Error("Could not unmarshal blacklist address - ignoring.")
+			return
+		}
+		freeze.Add(addr)
+
+		keepers.TreasuryKeeper.SetFreezeAddrs(ctx, freeze)
+
+	}
+
+}
+
+func runForkLogicBlacklist800MRebel(ctx sdk.Context, keepers *keepers.AppKeepers, mm *module.Manager) {
+
+	var freeze treasurytypes.FreezeList
+
+	if ctx.ChainID() == core.RebelChainID {
+
+		addr, err := sdk.AccAddressFromBech32("terra10zn3xx8nhvtdynux5tzjer23q2qpg0tz7xamut")
+		if err != nil {
+			ctx.Logger().Error("Could not unmarshal blacklist address - ignoring.")
+			return
+		}
+		freeze.Add(addr)
+
+		addr, err = sdk.AccAddressFromBech32("terra1njlydj87f05jmzdt9wmam0z28dlrc97qr6twqn")
+		if err != nil {
+			ctx.Logger().Error("Could not unmarshal blacklist address - ignoring.")
+			return
+		}
+		freeze.Add(addr)
+
+		keepers.TreasuryKeeper.SetFreezeAddrs(ctx, freeze)
+
 	}
 }

--- a/custom/auth/ante/ante.go
+++ b/custom/auth/ante/ante.go
@@ -1,6 +1,7 @@
 package ante
 
 import (
+	ibchostkeeper "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/host/keeper"
 	ibcante "github.com/cosmos/ibc-go/v6/modules/core/ante"
 	ibckeeper "github.com/cosmos/ibc-go/v6/modules/core/keeper"
 
@@ -29,6 +30,7 @@ type HandlerOptions struct {
 	SigGasConsumer         ante.SignatureVerificationGasConsumer
 	TxFeeChecker           ante.TxFeeChecker
 	IBCKeeper              ibckeeper.Keeper
+	HostKeeper             ibchostkeeper.Keeper
 	DistributionKeeper     distributionkeeper.Keeper
 	GovKeeper              govkeeper.Keeper
 	WasmConfig             *wasmtypes.WasmConfig
@@ -87,5 +89,6 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
 		ibcante.NewRedundantRelayDecorator(&options.IBCKeeper),
+		NewFreezeDecorator(options.Cdc, options.HostKeeper, options.TreasuryKeeper),
 	), nil
 }

--- a/custom/auth/ante/ante.go
+++ b/custom/auth/ante/ante.go
@@ -6,6 +6,7 @@ import (
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -17,6 +18,7 @@ import (
 
 // HandlerOptions are the options required for constructing a default SDK AnteHandler.
 type HandlerOptions struct {
+	Cdc                    codec.BinaryCodec
 	AccountKeeper          ante.AccountKeeper
 	BankKeeper             BankKeeper
 	ExtensionOptionChecker ante.ExtensionOptionChecker

--- a/custom/auth/ante/expected_keeper.go
+++ b/custom/auth/ante/expected_keeper.go
@@ -1,6 +1,7 @@
 package ante
 
 import (
+	treasurytypes "github.com/classic-terra/core/v2/x/treasury/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
@@ -15,6 +16,7 @@ type TreasuryKeeper interface {
 	HasBurnTaxExemptionAddress(ctx sdk.Context, addresses ...string) bool
 	HasBurnTaxExemptionContract(ctx sdk.Context, address string) bool
 	GetMinInitialDepositRatio(ctx sdk.Context) sdk.Dec
+	GetFreezeAddrs(ctx sdk.Context) treasurytypes.FreezeList
 }
 
 // OracleKeeper for feeder validation

--- a/custom/auth/ante/freeze.go
+++ b/custom/auth/ante/freeze.go
@@ -118,7 +118,7 @@ func (fd FreezeDecorator) FilterIbcPacket(ctx sdk.Context, packet channeltypes.P
 
 	var data icatypes.InterchainAccountPacketData
 	if icatypes.ModuleCdc.UnmarshalJSON(packet.GetData(), &data) != nil {
-		// jibberish or no ICA packet - we are good
+		ctx.Logger().Error("jibberish ICA message - no ICA packet - ignoring")
 		return nil
 	}
 
@@ -126,6 +126,7 @@ func (fd FreezeDecorator) FilterIbcPacket(ctx sdk.Context, packet channeltypes.P
 	case icatypes.EXECUTE_TX:
 		msgs, err := icatypes.DeserializeCosmosTx(fd.cdc, data.Data)
 		if err != nil {
+			ctx.Logger().Error("could not deserialize cosmos TX from ICA Message")
 			return nil
 		}
 		return fd.FilterMsgs(ctx, msgs)

--- a/custom/auth/ante/freeze.go
+++ b/custom/auth/ante/freeze.go
@@ -1,0 +1,116 @@
+package ante
+
+import (
+	"fmt"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	markettypes "github.com/classic-terra/core/v2/x/market/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	hostkeeper "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/host/keeper"
+	icatypes "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
+	channeltypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
+)
+
+var (
+	BlockedAddr = map[string]bool{}
+)
+
+// FreezeDecorator freezes wallets that should
+// not interact with the blockchain
+type FreezeDecorator struct {
+	cdc        codec.BinaryCodec
+	hostkeeper hostkeeper.Keeper
+}
+
+func NewFreezeDecorator(cdc codec.Codec, keeper hostkeeper.Keeper) FreezeDecorator {
+	return FreezeDecorator{
+		cdc:        cdc,
+		hostkeeper: keeper,
+	}
+}
+
+func (fd FreezeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+
+	msgs := tx.GetMsgs()
+	return ctx, fd.FilterMsgs(ctx, msgs)
+
+}
+
+func (fd FreezeDecorator) FilterMsgs(ctx sdk.Context, msgs []sdk.Msg) error {
+
+	for _, msg := range msgs {
+
+		switch v := msg.(type) {
+
+		case *banktypes.MsgSend:
+			if _, ok := BlockedAddr[v.FromAddress]; ok {
+				return fmt.Errorf("blocked address %s", v.FromAddress)
+			}
+		case *banktypes.MsgMultiSend:
+			for _, addr := range v.Inputs {
+				if _, ok := BlockedAddr[addr.Address]; ok {
+					return fmt.Errorf("blocked address %s", addr.Address)
+				}
+			}
+		case *markettypes.MsgSwapSend:
+			if _, ok := BlockedAddr[v.FromAddress]; ok {
+				return fmt.Errorf("blocked address %s", v.FromAddress)
+			}
+		case *markettypes.MsgSwap:
+			if _, ok := BlockedAddr[v.Trader]; ok {
+				return fmt.Errorf("blocked address %s", v.Trader)
+			}
+		case *wasmtypes.MsgExecuteContract:
+			if _, ok := BlockedAddr[v.Sender]; ok {
+				return fmt.Errorf("blocked address %s", v.Sender)
+			}
+		case *wasmtypes.MsgInstantiateContract:
+			if _, ok := BlockedAddr[v.Sender]; ok {
+				return fmt.Errorf("blocked address %s", v.Sender)
+			}
+		case *ibctransfertypes.MsgTransfer:
+			if _, ok := BlockedAddr[v.Sender]; ok {
+				return fmt.Errorf("blocked address %s", v.Sender)
+			}
+		case *authztypes.MsgExec:
+			msgs, err := v.GetMessages()
+			if err != nil {
+				continue
+			}
+			return fd.FilterMsgs(ctx, msgs)
+		case *channeltypes.MsgRecvPacket:
+			return fd.FilterIbcPacket(ctx, v.Packet)
+		default:
+			return nil
+		}
+	}
+
+	return nil
+
+}
+
+// FilterIbcPacket filters ICA Host messages
+func (fd FreezeDecorator) FilterIbcPacket(ctx sdk.Context, packet channeltypes.Packet) error {
+
+	var data icatypes.InterchainAccountPacketData
+	if icatypes.ModuleCdc.UnmarshalJSON(packet.GetData(), &data) != nil {
+		// jibberish or no ICA packet - we are good
+		return nil
+	}
+
+	switch data.Type {
+	case icatypes.EXECUTE_TX:
+		msgs, err := icatypes.DeserializeCosmosTx(fd.cdc, data.Data)
+		if err != nil {
+			return nil
+		}
+		return fd.FilterMsgs(ctx, msgs)
+	default:
+		return nil
+	}
+
+}

--- a/custom/auth/ante/freeze.go
+++ b/custom/auth/ante/freeze.go
@@ -45,18 +45,14 @@ func (fd FreezeDecorator) AnteHandle(
 	simulate bool,
 	next sdk.AnteHandler,
 ) (sdk.Context, error) {
-
 	msgs := tx.GetMsgs()
 	return ctx, fd.FilterMsgs(ctx, msgs)
-
 }
 
 func (fd FreezeDecorator) FilterMsgs(ctx sdk.Context, msgs []sdk.Msg) error {
-
 	BlockedAddr := fd.treasurykeeper.GetFreezeAddrs(ctx)
 
 	for _, msg := range msgs {
-
 		switch v := msg.(type) {
 
 		case *banktypes.MsgSend:
@@ -110,12 +106,10 @@ func (fd FreezeDecorator) FilterMsgs(ctx sdk.Context, msgs []sdk.Msg) error {
 	}
 
 	return nil
-
 }
 
 // FilterIbcPacket filters ICA Host messages
 func (fd FreezeDecorator) FilterIbcPacket(ctx sdk.Context, packet channeltypes.Packet) error {
-
 	var data icatypes.InterchainAccountPacketData
 	if icatypes.ModuleCdc.UnmarshalJSON(packet.GetData(), &data) != nil {
 		ctx.Logger().Error("jibberish ICA message - no ICA packet - ignoring")
@@ -133,5 +127,4 @@ func (fd FreezeDecorator) FilterIbcPacket(ctx sdk.Context, packet channeltypes.P
 	default:
 		return nil
 	}
-
 }

--- a/custom/auth/ante/freeze.go
+++ b/custom/auth/ante/freeze.go
@@ -61,39 +61,39 @@ func (fd FreezeDecorator) FilterMsgs(ctx sdk.Context, msgs []sdk.Msg) error {
 
 		case *banktypes.MsgSend:
 			addr, _ := sdk.AccAddressFromBech32(v.FromAddress)
-			if BlockedAddr.Contains(addr) {
+			if BlockedAddr.Contains(addr.String()) {
 				return fmt.Errorf("blocked address %s", v.FromAddress)
 			}
 		case *banktypes.MsgMultiSend:
 			for _, input := range v.Inputs {
 				addr, _ := sdk.AccAddressFromBech32(input.Address)
-				if BlockedAddr.Contains(addr) {
+				if BlockedAddr.Contains(addr.String()) {
 					return fmt.Errorf("blocked address %s", addr)
 				}
 			}
 		case *markettypes.MsgSwapSend:
 			addr, _ := sdk.AccAddressFromBech32(v.FromAddress)
-			if BlockedAddr.Contains(addr) {
+			if BlockedAddr.Contains(addr.String()) {
 				return fmt.Errorf("blocked address %s", v.FromAddress)
 			}
 		case *markettypes.MsgSwap:
 			addr, _ := sdk.AccAddressFromBech32(v.Trader)
-			if BlockedAddr.Contains(addr) {
+			if BlockedAddr.Contains(addr.String()) {
 				return fmt.Errorf("blocked address %s", v.Trader)
 			}
 		case *wasmtypes.MsgExecuteContract:
 			addr, _ := sdk.AccAddressFromBech32(v.Sender)
-			if BlockedAddr.Contains(addr) {
+			if BlockedAddr.Contains(addr.String()) {
 				return fmt.Errorf("blocked address %s", v.Sender)
 			}
 		case *wasmtypes.MsgInstantiateContract:
 			addr, _ := sdk.AccAddressFromBech32(v.Sender)
-			if BlockedAddr.Contains(addr) {
+			if BlockedAddr.Contains(addr.String()) {
 				return fmt.Errorf("blocked address %s", v.Sender)
 			}
 		case *ibctransfertypes.MsgTransfer:
 			addr, _ := sdk.AccAddressFromBech32(v.Sender)
-			if BlockedAddr.Contains(addr) {
+			if BlockedAddr.Contains(addr.String()) {
 				return fmt.Errorf("blocked address %s", v.Sender)
 			}
 		case *authztypes.MsgExec:

--- a/custom/auth/ante/freeze_test.go
+++ b/custom/auth/ante/freeze_test.go
@@ -1,0 +1,487 @@
+package ante_test
+
+import (
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/testutil/testdata"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
+	"github.com/cosmos/cosmos-sdk/x/bank/testutil"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	"github.com/classic-terra/core/v2/custom/auth/ante"
+	markettypes "github.com/classic-terra/core/v2/x/market/types"
+	treasurytypes "github.com/classic-terra/core/v2/x/treasury/types"
+	icatypes "github.com/cosmos/ibc-go/v6/modules/apps/27-interchain-accounts/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
+	clienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
+	channeltypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
+	"github.com/gogo/protobuf/proto"
+)
+
+func (s *AnteTestSuite) TestFreezeDecorator_BlockedBankSend() {
+	s.SetupTest(true) // setup
+	s.txBuilder = s.clientCtx.TxConfig.NewTxBuilder()
+
+	mfd := ante.NewFreezeDecorator(s.app.AppCodec(), s.app.ICAHostKeeper, s.app.TreasuryKeeper)
+	antehandler := sdk.ChainAnteDecorators(mfd)
+
+	// keys and addresses
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	_, _, addr2 := testdata.KeyTestPubAddr()
+	coins := sdk.NewCoins(sdk.NewCoin("atom", sdk.NewInt(300_000)))
+	send := sdk.NewCoins(sdk.NewCoin("atom", sdk.NewInt(100_000)))
+	testutil.FundAccount(s.app.BankKeeper, s.ctx, addr1, coins)
+
+	bankmsg := banktypes.NewMsgSend(addr1, addr2, send)
+	err := s.txBuilder.SetMsgs(bankmsg)
+	s.Require().NoError(err)
+	s.txBuilder.SetGasLimit(400_000)
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	tx, err := s.CreateTestTx(privs, accNums, accSeqs, s.ctx.ChainID())
+	s.Require().NoError(err)
+	s.ctx = s.ctx.WithIsCheckTx(true)
+
+	// set blocked address
+	blocked := treasurytypes.NewFreezeList()
+	blocked.Add(addr1.String())
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must fail
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().Error(err)
+
+	// set empty blocked addresses
+	blocked = treasurytypes.NewFreezeList()
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must succeed
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().NoError(err)
+
+}
+
+func (s *AnteTestSuite) TestFreezeDecorator_BlockedBankMultiSend() {
+	s.SetupTest(true) // setup
+	s.txBuilder = s.clientCtx.TxConfig.NewTxBuilder()
+
+	mfd := ante.NewFreezeDecorator(s.app.AppCodec(), s.app.ICAHostKeeper, s.app.TreasuryKeeper)
+	antehandler := sdk.ChainAnteDecorators(mfd)
+
+	// keys and addresses
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	_, _, addr2 := testdata.KeyTestPubAddr()
+	coins := sdk.NewCoins(sdk.NewCoin("atom", sdk.NewInt(300_000)))
+	send := sdk.NewCoins(sdk.NewCoin("atom", sdk.NewInt(100_000)))
+	testutil.FundAccount(s.app.BankKeeper, s.ctx, addr1, coins)
+
+	bankmsg := banktypes.NewMsgMultiSend(
+		[]banktypes.Input{banktypes.NewInput(addr1, send)},
+		[]banktypes.Output{banktypes.NewOutput(addr2, send)},
+	)
+	err := s.txBuilder.SetMsgs(bankmsg)
+	s.Require().NoError(err)
+	s.txBuilder.SetGasLimit(400_000)
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	tx, err := s.CreateTestTx(privs, accNums, accSeqs, s.ctx.ChainID())
+	s.Require().NoError(err)
+	s.ctx = s.ctx.WithIsCheckTx(true)
+
+	// set blocked address
+	blocked := treasurytypes.NewFreezeList()
+	blocked.Add(addr1.String())
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must fail
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().Error(err)
+
+	// set empty blocked addresses
+	blocked = treasurytypes.NewFreezeList()
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must succeed
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().NoError(err)
+
+}
+
+func (s *AnteTestSuite) TestFreezeDecorator_BlockedSwapSend() {
+	s.SetupTest(true) // setup
+	s.txBuilder = s.clientCtx.TxConfig.NewTxBuilder()
+
+	mfd := ante.NewFreezeDecorator(s.app.AppCodec(), s.app.ICAHostKeeper, s.app.TreasuryKeeper)
+	antehandler := sdk.ChainAnteDecorators(mfd)
+
+	// keys and addresses
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	_, _, addr2 := testdata.KeyTestPubAddr()
+	coins := sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(300_000)))
+	send := sdk.NewCoin("uluna", sdk.NewInt(100_000))
+	testutil.FundAccount(s.app.BankKeeper, s.ctx, addr1, coins)
+
+	marketmsg := markettypes.NewMsgSwapSend(addr1, addr2, send, "uusd")
+	err := s.txBuilder.SetMsgs(marketmsg)
+	s.Require().NoError(err)
+	s.txBuilder.SetGasLimit(400_000)
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	tx, err := s.CreateTestTx(privs, accNums, accSeqs, s.ctx.ChainID())
+	s.Require().NoError(err)
+	s.ctx = s.ctx.WithIsCheckTx(true)
+
+	// set blocked address
+	blocked := treasurytypes.NewFreezeList()
+	blocked.Add(addr1.String())
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must fail
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().Error(err)
+
+	// set empty blocked addresses
+	blocked = treasurytypes.NewFreezeList()
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must succeed
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().NoError(err)
+
+}
+
+func (s *AnteTestSuite) TestFreezeDecorator_BlockedSwap() {
+	s.SetupTest(true) // setup
+	s.txBuilder = s.clientCtx.TxConfig.NewTxBuilder()
+
+	mfd := ante.NewFreezeDecorator(s.app.AppCodec(), s.app.ICAHostKeeper, s.app.TreasuryKeeper)
+	antehandler := sdk.ChainAnteDecorators(mfd)
+
+	// keys and addresses
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	coins := sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(300_000)))
+	send := sdk.NewCoin("uluna", sdk.NewInt(100_000))
+	testutil.FundAccount(s.app.BankKeeper, s.ctx, addr1, coins)
+
+	marketmsg := markettypes.NewMsgSwap(addr1, send, "uusd")
+	err := s.txBuilder.SetMsgs(marketmsg)
+	s.Require().NoError(err)
+	s.txBuilder.SetGasLimit(400_000)
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	tx, err := s.CreateTestTx(privs, accNums, accSeqs, s.ctx.ChainID())
+	s.Require().NoError(err)
+	s.ctx = s.ctx.WithIsCheckTx(true)
+
+	// set blocked address
+	blocked := treasurytypes.NewFreezeList()
+	blocked.Add(addr1.String())
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must fail
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().Error(err)
+
+	// set empty blocked addresses
+	blocked = treasurytypes.NewFreezeList()
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must succeed
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().NoError(err)
+
+}
+
+func (s *AnteTestSuite) TestFreezeDecorator_BlockedInstantiateContract() {
+	s.SetupTest(true) // setup
+	s.txBuilder = s.clientCtx.TxConfig.NewTxBuilder()
+
+	mfd := ante.NewFreezeDecorator(s.app.AppCodec(), s.app.ICAHostKeeper, s.app.TreasuryKeeper)
+	antehandler := sdk.ChainAnteDecorators(mfd)
+
+	// keys and addresses
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	coins := sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(300_000)))
+	send := sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(100_000)))
+	testutil.FundAccount(s.app.BankKeeper, s.ctx, addr1, coins)
+
+	wasmmsg := wasmtypes.MsgInstantiateContract{
+		Sender: addr1.String(),
+		Admin:  addr1.String(),
+		CodeID: 1,
+		Label:  "dummy",
+		Msg:    []byte("{}"),
+		Funds:  send,
+	}
+	err := s.txBuilder.SetMsgs(&wasmmsg)
+	s.Require().NoError(err)
+	s.txBuilder.SetGasLimit(400_000)
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	tx, err := s.CreateTestTx(privs, accNums, accSeqs, s.ctx.ChainID())
+	s.Require().NoError(err)
+	s.ctx = s.ctx.WithIsCheckTx(true)
+
+	// set blocked address
+	blocked := treasurytypes.NewFreezeList()
+	blocked.Add(addr1.String())
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must fail
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().Error(err)
+
+	// set empty blocked addresses
+	blocked = treasurytypes.NewFreezeList()
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must succeed
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().NoError(err)
+
+}
+
+func (s *AnteTestSuite) TestFreezeDecorator_BlockedMsgInstantiateContract2() {
+	s.SetupTest(true) // setup
+	s.txBuilder = s.clientCtx.TxConfig.NewTxBuilder()
+
+	mfd := ante.NewFreezeDecorator(s.app.AppCodec(), s.app.ICAHostKeeper, s.app.TreasuryKeeper)
+	antehandler := sdk.ChainAnteDecorators(mfd)
+
+	// keys and addresses
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	coins := sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(300_000)))
+	send := sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(100_000)))
+	testutil.FundAccount(s.app.BankKeeper, s.ctx, addr1, coins)
+
+	wasmmsg := wasmtypes.MsgInstantiateContract2{
+		Sender: addr1.String(),
+		Admin:  addr1.String(),
+		CodeID: 1,
+		Label:  "dummy",
+		Msg:    []byte("{}"),
+		Funds:  send,
+		Salt:   []byte("crytal"),
+		FixMsg: true,
+	}
+	err := s.txBuilder.SetMsgs(&wasmmsg)
+	s.Require().NoError(err)
+	s.txBuilder.SetGasLimit(400_000)
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	tx, err := s.CreateTestTx(privs, accNums, accSeqs, s.ctx.ChainID())
+	s.Require().NoError(err)
+	s.ctx = s.ctx.WithIsCheckTx(true)
+
+	// set blocked address
+	blocked := treasurytypes.NewFreezeList()
+	blocked.Add(addr1.String())
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must fail
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().Error(err)
+
+	// set empty blocked addresses
+	blocked = treasurytypes.NewFreezeList()
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must succeed
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().NoError(err)
+
+}
+
+func (s *AnteTestSuite) TestFreezeDecorator_BlockedExecuteContract() {
+	s.SetupTest(true) // setup
+	s.txBuilder = s.clientCtx.TxConfig.NewTxBuilder()
+
+	mfd := ante.NewFreezeDecorator(s.app.AppCodec(), s.app.ICAHostKeeper, s.app.TreasuryKeeper)
+	antehandler := sdk.ChainAnteDecorators(mfd)
+
+	// keys and addresses
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	coins := sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(300_000)))
+	send := sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(100_000)))
+	testutil.FundAccount(s.app.BankKeeper, s.ctx, addr1, coins)
+
+	wasmmsg := wasmtypes.MsgExecuteContract{
+		Sender:   addr1.String(),
+		Contract: "mycontractaddress",
+		Msg:      []byte("{}"),
+		Funds:    send,
+	}
+	err := s.txBuilder.SetMsgs(&wasmmsg)
+	s.Require().NoError(err)
+	s.txBuilder.SetGasLimit(400_000)
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	tx, err := s.CreateTestTx(privs, accNums, accSeqs, s.ctx.ChainID())
+	s.Require().NoError(err)
+	s.ctx = s.ctx.WithIsCheckTx(true)
+
+	// set blocked address
+	blocked := treasurytypes.NewFreezeList()
+	blocked.Add(addr1.String())
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must fail
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().Error(err)
+
+	// set empty blocked addresses
+	blocked = treasurytypes.NewFreezeList()
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must succeed
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().NoError(err)
+
+}
+
+func (s *AnteTestSuite) TestFreezeDecorator_BlockedMsgTransfer() {
+	s.SetupTest(true) // setup
+	s.txBuilder = s.clientCtx.TxConfig.NewTxBuilder()
+
+	mfd := ante.NewFreezeDecorator(s.app.AppCodec(), s.app.ICAHostKeeper, s.app.TreasuryKeeper)
+	antehandler := sdk.ChainAnteDecorators(mfd)
+
+	// keys and addresses
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	_, _, addr2 := testdata.KeyTestPubAddr()
+	coins := sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(300_000)))
+	sendcoin := sdk.NewCoin("uluna", sdk.NewInt(100_000))
+	testutil.FundAccount(s.app.BankKeeper, s.ctx, addr1, coins)
+
+	ibcmsg := ibctransfertypes.NewMsgTransfer(
+		"transfer", "channel-0", sendcoin,
+		addr1.String(), addr2.String(), clienttypes.NewHeight(1, 1), 0,
+		"awesomeibc",
+	)
+	err := s.txBuilder.SetMsgs(ibcmsg)
+	s.Require().NoError(err)
+	s.txBuilder.SetGasLimit(400_000)
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	tx, err := s.CreateTestTx(privs, accNums, accSeqs, s.ctx.ChainID())
+	s.Require().NoError(err)
+	s.ctx = s.ctx.WithIsCheckTx(true)
+
+	// set blocked address
+	blocked := treasurytypes.NewFreezeList()
+	blocked.Add(addr1.String())
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must fail
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().Error(err)
+
+	// set empty blocked addresses
+	blocked = treasurytypes.NewFreezeList()
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must succeed
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().NoError(err)
+
+}
+
+func (s *AnteTestSuite) TestFreezeDecorator_BlockedAuthz() {
+	s.SetupTest(true) // setup
+	s.txBuilder = s.clientCtx.TxConfig.NewTxBuilder()
+
+	mfd := ante.NewFreezeDecorator(s.app.AppCodec(), s.app.ICAHostKeeper, s.app.TreasuryKeeper)
+	antehandler := sdk.ChainAnteDecorators(mfd)
+
+	// keys and addresses
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	_, _, addr2 := testdata.KeyTestPubAddr()
+	_, _, grantee := testdata.KeyTestPubAddr()
+	coins := sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(300_000)))
+	sendcoins := sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(100_000)))
+	testutil.FundAccount(s.app.BankKeeper, s.ctx, addr1, coins)
+
+	wrappedmsg := banktypes.NewMsgSend(addr1, addr2, sendcoins)
+	authzmsg := authztypes.NewMsgExec(grantee, []sdk.Msg{wrappedmsg})
+	err := s.txBuilder.SetMsgs(&authzmsg)
+	s.Require().NoError(err)
+	s.txBuilder.SetGasLimit(400_000)
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	tx, err := s.CreateTestTx(privs, accNums, accSeqs, s.ctx.ChainID())
+	s.Require().NoError(err)
+	s.ctx = s.ctx.WithIsCheckTx(true)
+
+	// set blocked address
+	blocked := treasurytypes.NewFreezeList()
+	blocked.Add(addr1.String())
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must fail
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().Error(err)
+
+	// set empty blocked addresses
+	blocked = treasurytypes.NewFreezeList()
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must succeed
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().NoError(err)
+
+}
+
+func (s *AnteTestSuite) TestFreezeDecorator_BlockedIbcHostMsg() {
+	s.SetupTest(true) // setup
+	s.txBuilder = s.clientCtx.TxConfig.NewTxBuilder()
+
+	mfd := ante.NewFreezeDecorator(s.app.AppCodec(), s.app.ICAHostKeeper, s.app.TreasuryKeeper)
+	antehandler := sdk.ChainAnteDecorators(mfd)
+
+	// keys and addresses
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	_, _, addr2 := testdata.KeyTestPubAddr()
+	coins := sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(300_000)))
+	sendcoins := sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(100_000)))
+	testutil.FundAccount(s.app.BankKeeper, s.ctx, addr1, coins)
+
+	wrappedmsg := &banktypes.MsgSend{
+		FromAddress: addr1.String(),
+		ToAddress:   addr2.String(),
+		Amount:      sendcoins,
+	}
+	bz, err := icatypes.SerializeCosmosTx(s.app.AppCodec(), []proto.Message{wrappedmsg})
+	s.Require().NoError(err)
+	hostpacketdata := &icatypes.InterchainAccountPacketData{
+		Type: icatypes.EXECUTE_TX,
+		Data: bz,
+		Memo: "awsesomeinterchain",
+	}
+	bz2 := icatypes.ModuleCdc.MustMarshalJSON(hostpacketdata)
+	packet := channeltypes.NewPacket(
+		bz2, 1, "srcport", "srcchannel",
+		"dstport", "dstchannel",
+		clienttypes.NewHeight(1, 1), 0,
+	)
+	recvmsg := channeltypes.NewMsgRecvPacket(
+		packet, []byte("proof"), clienttypes.NewHeight(1, 1),
+		addr1.String(),
+	)
+	err = s.txBuilder.SetMsgs(recvmsg)
+	s.Require().NoError(err)
+	s.txBuilder.SetGasLimit(400_000)
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	tx, err := s.CreateTestTx(privs, accNums, accSeqs, s.ctx.ChainID())
+	s.Require().NoError(err)
+	s.ctx = s.ctx.WithIsCheckTx(true)
+
+	// set blocked address
+	blocked := treasurytypes.NewFreezeList()
+	blocked.Add(addr1.String())
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must fail
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().Error(err)
+
+	// set empty blocked addresses
+	blocked = treasurytypes.NewFreezeList()
+	s.app.TreasuryKeeper.SetFreezeAddrs(s.ctx, blocked)
+
+	// must succeed
+	_, err = antehandler(s.ctx, tx, false)
+	s.Require().NoError(err)
+
+}

--- a/custom/auth/ante/freeze_test.go
+++ b/custom/auth/ante/freeze_test.go
@@ -58,7 +58,6 @@ func (s *AnteTestSuite) TestFreezeDecorator_BlockedBankSend() {
 	// must succeed
 	_, err = antehandler(s.ctx, tx, false)
 	s.Require().NoError(err)
-
 }
 
 func (s *AnteTestSuite) TestFreezeDecorator_BlockedBankMultiSend() {
@@ -103,7 +102,6 @@ func (s *AnteTestSuite) TestFreezeDecorator_BlockedBankMultiSend() {
 	// must succeed
 	_, err = antehandler(s.ctx, tx, false)
 	s.Require().NoError(err)
-
 }
 
 func (s *AnteTestSuite) TestFreezeDecorator_BlockedSwapSend() {
@@ -145,7 +143,6 @@ func (s *AnteTestSuite) TestFreezeDecorator_BlockedSwapSend() {
 	// must succeed
 	_, err = antehandler(s.ctx, tx, false)
 	s.Require().NoError(err)
-
 }
 
 func (s *AnteTestSuite) TestFreezeDecorator_BlockedSwap() {
@@ -186,7 +183,6 @@ func (s *AnteTestSuite) TestFreezeDecorator_BlockedSwap() {
 	// must succeed
 	_, err = antehandler(s.ctx, tx, false)
 	s.Require().NoError(err)
-
 }
 
 func (s *AnteTestSuite) TestFreezeDecorator_BlockedInstantiateContract() {
@@ -234,7 +230,6 @@ func (s *AnteTestSuite) TestFreezeDecorator_BlockedInstantiateContract() {
 	// must succeed
 	_, err = antehandler(s.ctx, tx, false)
 	s.Require().NoError(err)
-
 }
 
 func (s *AnteTestSuite) TestFreezeDecorator_BlockedMsgInstantiateContract2() {
@@ -284,7 +279,6 @@ func (s *AnteTestSuite) TestFreezeDecorator_BlockedMsgInstantiateContract2() {
 	// must succeed
 	_, err = antehandler(s.ctx, tx, false)
 	s.Require().NoError(err)
-
 }
 
 func (s *AnteTestSuite) TestFreezeDecorator_BlockedExecuteContract() {
@@ -330,7 +324,6 @@ func (s *AnteTestSuite) TestFreezeDecorator_BlockedExecuteContract() {
 	// must succeed
 	_, err = antehandler(s.ctx, tx, false)
 	s.Require().NoError(err)
-
 }
 
 func (s *AnteTestSuite) TestFreezeDecorator_BlockedMsgTransfer() {
@@ -376,7 +369,6 @@ func (s *AnteTestSuite) TestFreezeDecorator_BlockedMsgTransfer() {
 	// must succeed
 	_, err = antehandler(s.ctx, tx, false)
 	s.Require().NoError(err)
-
 }
 
 func (s *AnteTestSuite) TestFreezeDecorator_BlockedAuthz() {
@@ -420,7 +412,6 @@ func (s *AnteTestSuite) TestFreezeDecorator_BlockedAuthz() {
 	// must succeed
 	_, err = antehandler(s.ctx, tx, false)
 	s.Require().NoError(err)
-
 }
 
 func (s *AnteTestSuite) TestFreezeDecorator_BlockedIbcHostMsg() {
@@ -483,5 +474,4 @@ func (s *AnteTestSuite) TestFreezeDecorator_BlockedIbcHostMsg() {
 	// must succeed
 	_, err = antehandler(s.ctx, tx, false)
 	s.Require().NoError(err)
-
 }

--- a/types/fork/fork.go
+++ b/types/fork/fork.go
@@ -23,4 +23,8 @@ const (
 	// Revert Min Commission slip during v2.2.0 upgrade
 	FixMinCommissionHeight      = int64(14_890_000)
 	FixMinCommissionHeightRebel = int64(16_300_000)
+	// Freeze 800M USTC wallet
+	Freeze800MHeight      = int64(15_000_000) // TODO: TBD
+	Freeze800MHeightRebel = int64(15_000_000) // TODO: TBD
+
 )

--- a/x/treasury/keeper/freeze.go
+++ b/x/treasury/keeper/freeze.go
@@ -9,7 +9,6 @@ import (
 
 // GetFreezeAddrs
 func (k Keeper) GetFreezeAddrs(ctx sdk.Context) types.FreezeList {
-
 	store := ctx.KVStore(k.storeKey)
 
 	b := store.Get(types.FreezeKey)
@@ -24,12 +23,10 @@ func (k Keeper) GetFreezeAddrs(ctx sdk.Context) types.FreezeList {
 	}
 
 	return list
-
 }
 
 // SetFreezeAddrs
 func (k Keeper) SetFreezeAddrs(ctx sdk.Context, list types.FreezeList) {
-
 	store := ctx.KVStore(k.storeKey)
 
 	bz, err := json.Marshal(list)
@@ -38,5 +35,4 @@ func (k Keeper) SetFreezeAddrs(ctx sdk.Context, list types.FreezeList) {
 	}
 
 	store.Set(types.FreezeKey, bz)
-
 }

--- a/x/treasury/keeper/freeze.go
+++ b/x/treasury/keeper/freeze.go
@@ -1,0 +1,37 @@
+package keeper
+
+import (
+	"encoding/json"
+
+	"github.com/classic-terra/core/v2/x/treasury/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// GetFreezeAddrs
+func (k Keeper) GetFreezeAddrs(ctx sdk.Context) types.FreezeList {
+	store := ctx.KVStore(k.storeKey)
+	b := store.Get(types.FreezeKey)
+	if b == nil {
+		return types.NewFreezeList()
+	}
+
+	list := types.NewFreezeList()
+	if err := json.Unmarshal(b, &list); err != nil {
+		return types.NewFreezeList()
+	}
+
+	return list
+
+}
+
+// SetFreezeAddrs
+func (k Keeper) SetFreezeAddrs(ctx sdk.Context, list types.FreezeList) {
+	store := ctx.KVStore(k.storeKey)
+	bz, err := json.Marshal(list)
+	if err != nil {
+		return
+	}
+
+	store.Set(types.FreezeKey, bz)
+
+}

--- a/x/treasury/keeper/freeze.go
+++ b/x/treasury/keeper/freeze.go
@@ -9,14 +9,17 @@ import (
 
 // GetFreezeAddrs
 func (k Keeper) GetFreezeAddrs(ctx sdk.Context) types.FreezeList {
+
 	store := ctx.KVStore(k.storeKey)
+
 	b := store.Get(types.FreezeKey)
 	if b == nil {
 		return types.NewFreezeList()
 	}
 
 	list := types.NewFreezeList()
-	if err := json.Unmarshal(b, &list); err != nil {
+	err := json.Unmarshal(b, &list)
+	if err != nil {
 		return types.NewFreezeList()
 	}
 
@@ -26,7 +29,9 @@ func (k Keeper) GetFreezeAddrs(ctx sdk.Context) types.FreezeList {
 
 // SetFreezeAddrs
 func (k Keeper) SetFreezeAddrs(ctx sdk.Context, list types.FreezeList) {
+
 	store := ctx.KVStore(k.storeKey)
+
 	bz, err := json.Marshal(list)
 	if err != nil {
 		return

--- a/x/treasury/keeper/freeze_test.go
+++ b/x/treasury/keeper/freeze_test.go
@@ -1,0 +1,32 @@
+package keeper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/classic-terra/core/v2/x/treasury/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFreezeListSetGet(t *testing.T) {
+	input := CreateTestInput(t)
+
+	// Should be empty after initialization
+	freeze := input.TreasuryKeeper.GetFreezeAddrs(input.Ctx)
+	require.Equal(t, 0, len(freeze.Frozen))
+
+	// Setting
+	freeze2 := types.NewFreezeList()
+	freeze2.Add("test2")
+	freeze2.Add("test3")
+	input.TreasuryKeeper.SetFreezeAddrs(input.Ctx, freeze2)
+	fmt.Printf("freeze2: %v\n", freeze2)
+
+	// Should contain correct data after receive
+	freeze3 := input.TreasuryKeeper.GetFreezeAddrs(input.Ctx)
+	fmt.Printf("freeze3: %v\n", freeze3)
+	require.Equal(t, 2, len(freeze3.Frozen))
+	require.Equal(t, "test2", freeze3.Frozen[0])
+	require.Equal(t, "test3", freeze3.Frozen[1])
+
+}

--- a/x/treasury/keeper/freeze_test.go
+++ b/x/treasury/keeper/freeze_test.go
@@ -28,5 +28,4 @@ func TestFreezeListSetGet(t *testing.T) {
 	require.Equal(t, 2, len(freeze3.Frozen))
 	require.Equal(t, "test2", freeze3.Frozen[0])
 	require.Equal(t, "test3", freeze3.Frozen[1])
-
 }

--- a/x/treasury/types/freeze.go
+++ b/x/treasury/types/freeze.go
@@ -1,0 +1,41 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type FreezeList struct {
+	Frozen []sdk.Address `json:"frozen"`
+}
+
+func NewFreezeList() FreezeList {
+	return FreezeList{
+		Frozen: []sdk.Address{},
+	}
+}
+
+func (fl FreezeList) Contains(target sdk.Address) bool {
+	return sdk.SliceContains(fl.Frozen, target)
+}
+
+func (fl FreezeList) Add(target sdk.Address) {
+	if fl.Contains(target) {
+		return
+	}
+	fl.Frozen = append(fl.Frozen, target)
+}
+
+func (fl FreezeList) Remove(target sdk.Address) {
+	if !fl.Contains(target) {
+		return
+	}
+
+	var updated []sdk.Address
+	for _, item := range fl.Frozen {
+		if item != target {
+			updated = append(updated, item)
+		}
+	}
+	fl.Frozen = updated
+
+}

--- a/x/treasury/types/freeze.go
+++ b/x/treasury/types/freeze.go
@@ -5,32 +5,33 @@ import (
 )
 
 type FreezeList struct {
-	Frozen []sdk.Address `json:"frozen"`
+	Frozen []string `json:"frozen"`
 }
 
 func NewFreezeList() FreezeList {
 	return FreezeList{
-		Frozen: []sdk.Address{},
+		Frozen: []string{},
 	}
 }
 
-func (fl FreezeList) Contains(target sdk.Address) bool {
+func (fl *FreezeList) Contains(target string) bool {
 	return sdk.SliceContains(fl.Frozen, target)
 }
 
-func (fl FreezeList) Add(target sdk.Address) {
+func (fl *FreezeList) Add(target string) {
 	if fl.Contains(target) {
 		return
 	}
 	fl.Frozen = append(fl.Frozen, target)
+
 }
 
-func (fl FreezeList) Remove(target sdk.Address) {
+func (fl *FreezeList) Remove(target string) {
 	if !fl.Contains(target) {
 		return
 	}
 
-	var updated []sdk.Address
+	var updated []string
 	for _, item := range fl.Frozen {
 		if item != target {
 			updated = append(updated, item)

--- a/x/treasury/types/freeze.go
+++ b/x/treasury/types/freeze.go
@@ -23,7 +23,6 @@ func (fl *FreezeList) Add(target string) {
 		return
 	}
 	fl.Frozen = append(fl.Frozen, target)
-
 }
 
 func (fl *FreezeList) Remove(target string) {
@@ -38,5 +37,4 @@ func (fl *FreezeList) Remove(target string) {
 		}
 	}
 	fl.Frozen = updated
-
 }

--- a/x/treasury/types/freeze_test.go
+++ b/x/treasury/types/freeze_test.go
@@ -1,0 +1,75 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestFreezeListContains(t *testing.T) {
+	fl := NewFreezeList()
+	addr1 := "cosmos10zn3xx8nhvtdynux5tzjer23q2qpg0tzcz8m7t"
+	addr2 := "cosmos1njlydj87f05jmzdt9wmam0z28dlrc97q973wzn"
+
+	if fl.Contains(addr1) {
+		t.Errorf("Expected Contains() to return false for an empty FreezeList")
+	}
+
+	fl.Add(addr1)
+	if !fl.Contains(addr1) {
+		t.Errorf("Expected Contains() to return true after adding the address")
+	}
+
+	if fl.Contains(addr2) {
+		t.Errorf("Expected Contains() to return false for an address that hasn't been added")
+	}
+}
+
+func TestFreezeListAdd(t *testing.T) {
+	fl := NewFreezeList()
+	addr1 := "cosmos10zn3xx8nhvtdynux5tzjer23q2qpg0tzcz8m7t"
+
+	// Add an address
+	fl.Add(addr1)
+
+	if !fl.Contains(addr1) {
+		t.Errorf("Expected Add() to add the address to FreezeList")
+	}
+
+	// Add the same address again, it should not be duplicated
+	fl.Add(addr1)
+	if len(fl.Frozen) != 1 {
+		t.Errorf("Expected Add() not to duplicate the address in FreezeList")
+	}
+}
+
+func TestFreezeListRemove(t *testing.T) {
+	fl := NewFreezeList()
+	addr1 := "cosmos10zn3xx8nhvtdynux5tzjer23q2qpg0tzcz8m7t"
+	addr2 := "cosmos1njlydj87f05jmzdt9wmam0z28dlrc97q973wzn"
+
+	// Try to remove an address from an empty FreezeList
+	fl.Remove(addr1)
+	if len(fl.Frozen) != 0 {
+		t.Errorf("Expected Remove() to have no effect on an empty FreezeList")
+	}
+
+	// Add an address and then remove it
+	fl.Add(addr1)
+	fl.Remove(addr1)
+	if len(fl.Frozen) != 0 || fl.Contains(addr1) {
+		t.Errorf("Expected Remove() to remove the added address from FreezeList")
+	}
+
+	// Try to remove an address that was not added
+	fl.Remove(addr2)
+	if len(fl.Frozen) != 0 {
+		t.Errorf("Expected Remove() not to affect FreezeList when removing an address that wasn't added")
+	}
+}
+
+func TestFreezeListNewFreezeList(t *testing.T) {
+	fl := NewFreezeList()
+
+	if len(fl.Frozen) != 0 {
+		t.Errorf("Expected NewFreezeList() to create an empty FreezeList")
+	}
+}

--- a/x/treasury/types/keys.go
+++ b/x/treasury/types/keys.go
@@ -53,9 +53,10 @@ var (
 	BurnTaxExemptionListPrefix = []byte{0x20} // prefix for burn tax exemption list
 
 	// Keys for store prefixes of internal purpose variables
-	TRKey  = []byte{0x06} // prefix for each key to a TR
-	SRKey  = []byte{0x07} // prefix for each key to a SR
-	TSLKey = []byte{0x08} // prefix for each key to a TSL
+	TRKey     = []byte{0x06} // prefix for each key to a TR
+	SRKey     = []byte{0x07} // prefix for each key to a SR
+	TSLKey    = []byte{0x08} // prefix for each key to a TSL
+	FreezeKey = []byte{0x30}
 )
 
 // GetTaxCapKey - stored by *denom*


### PR DESCRIPTION
This is the 800M USTC wallet blacklist code as passed by governance proposal [11832]( https://station.terra.money/proposal/columbus-5/11832). The changes of this PR include:

- Block various on-chain Messages (including IBC transfer) from being executed when sender is blacklisted
- Block ICA messages from being executed when the wrapped Messages match the above criteria
- Block authz executions if the wrapped Messages match the above criteria
- Save blacklist as on-chain in-store variable inside the treasury keeper
- In-Store blacklist variable cannot be modified by governance (only through soft-fork)
- Tests

**TODO:**

- Block `MsgInstantiateContract2`
- Determine appropriate fork heights for `rebel-2` and `columbus-5`
- Code changes should be non-state breaking if no fork is applied (test this on live node)
- Create `rebel-2` testnet addresses (including multisig) to test this in integration (these addresses need to be put into the code as well)