### PR TITLE
fix: last cleanup - prepare v2.3.0

### DIFF
--- a/x/dyncomm/abci.go
+++ b/x/dyncomm/abci.go
@@ -16,9 +16,7 @@ import (
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyEndBlocker)
 
-	// Check epoch last block
-	// TODO: Change this to the appropriate period
-	if !core.IsPeriodLastBlock(ctx, 10*core.BlocksPerMinute) {
+	if !core.IsPeriodLastBlock(ctx, core.BlocksPerWeek) {
 		return
 	}
 


### PR DESCRIPTION
This PR is just setting the epoch length of dyncomm modules recalculation from 10minutes to 7days (how it's supposed to be on `columbus-5` mainnet). This change needs a chain halt on rebel-2 network and will be coordinated with the testnet validators accordingly. This PR is supposed to mark `v2.3.0` release to introduce dyncomm on `columbus-5`.
