### PR TITLE
fix: wrong logic in handling tax for `MsgExec`

### DIFF
--- a/custom/auth/ante/fee_tax.go
+++ b/custom/auth/ante/fee_tax.go
@@ -67,7 +67,7 @@ func FilterMsgAndComputeTax(ctx sdk.Context, tk TreasuryKeeper, msgs ...sdk.Msg)
 
 		case *authz.MsgExec:
 			messages, err := msg.GetMessages()
-			if err != nil {
+			if err == nil {
 				taxes = taxes.Add(FilterMsgAndComputeTax(ctx, tk, messages...)...)
 			}
 		}


### PR DESCRIPTION
## Summary of changes

This bug slipped through when the `MsgExec` was added to the tax handling.
