### PR TITLE
fix: initial deposit for v1 props

### DIFF
--- a/custom/auth/ante/min_initial_deposit.go
+++ b/custom/auth/ante/min_initial_deposit.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 )
 
@@ -26,15 +27,26 @@ func NewMinInitialDepositDecorator(govKeeper govkeeper.Keeper, treasuryKeeper Tr
 
 // IsMsgSubmitProposal checks whether the input msg is a MsgSubmitProposal
 func IsMsgSubmitProposal(msg sdk.Msg) bool {
-	_, ok := msg.(*govv1beta1.MsgSubmitProposal)
-	return ok
+	_, okv1beta1 := msg.(*govv1beta1.MsgSubmitProposal)
+	_, okv1 := msg.(*govv1.MsgSubmitProposal)
+	return okv1beta1 || okv1
 }
 
 // HandleCheckMinInitialDeposit
 func HandleCheckMinInitialDeposit(ctx sdk.Context, msg sdk.Msg, govKeeper govkeeper.Keeper, treasuryKeeper TreasuryKeeper) (err error) {
-	submitPropMsg, ok := msg.(*govv1beta1.MsgSubmitProposal)
-	if !ok {
+	submitPropMsgV1Beta1, okV1Beta1 := msg.(*govv1beta1.MsgSubmitProposal)
+	submitPropMsgV1, okV1 := msg.(*govv1.MsgSubmitProposal)
+
+	if !(okV1Beta1 || okV1) {
 		return fmt.Errorf("could not dereference msg as MsgSubmitProposal")
+	}
+
+	var initialDepositCoins sdk.Coins
+
+	if okV1Beta1 {
+		initialDepositCoins = submitPropMsgV1Beta1.GetInitialDeposit()
+	} else if okV1 {
+		initialDepositCoins = submitPropMsgV1.GetInitialDeposit()
 	}
 
 	minDeposit := govKeeper.GetDepositParams(ctx).MinDeposit
@@ -43,7 +55,6 @@ func HandleCheckMinInitialDeposit(ctx sdk.Context, msg sdk.Msg, govKeeper govkee
 	requiredDepositCoins := sdk.NewCoins(
 		sdk.NewCoin(core.MicroLunaDenom, requiredAmount),
 	)
-	initialDepositCoins := submitPropMsg.GetInitialDeposit()
 
 	if !initialDepositCoins.IsAllGTE(requiredDepositCoins) {
 		return fmt.Errorf("not enough initial deposit provided. Expected %q; got %q", requiredDepositCoins, initialDepositCoins)

--- a/custom/auth/ante/min_initial_deposit_test.go
+++ b/custom/auth/ante/min_initial_deposit_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/classic-terra/core/v2/custom/auth/ante"
 	core "github.com/classic-terra/core/v2/types"
+
 	// core "github.com/terra-money/core/types"
 	// treasury "github.com/terra-money/core/x/treasury/types"
 
@@ -60,6 +61,21 @@ func (suite *AnteTestSuite) TestMinInitialDepositRatioDefault() {
 	// antehandler should not error
 	_, err = antehandler(suite.ctx, tx, false)
 	suite.Require().NoError(err, "error: Proposal whithout initial deposit should have gone through")
+
+	// create v1 proposal
+	msgv1, _ := govv1.NewMsgSubmitProposal([]sdk.Msg{}, depositCoins1, addr1.String(), "metadata")
+	feeAmountv1 := testdata.NewTestFeeAmount()
+	gasLimitv1 := testdata.NewTestGasLimit()
+	suite.Require().NoError(suite.txBuilder.SetMsgs(msgv1))
+	suite.txBuilder.SetFeeAmount(feeAmountv1)
+	suite.txBuilder.SetGasLimit(gasLimitv1)
+	privs, accNums, accSeqs = []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	txv1, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
+	suite.Require().NoError(err)
+
+	// ante handler should not error for v1 proposal
+	_, err = antehandler(suite.ctx, txv1, false)
+	suite.Require().NoError(err, "error: v1 proposal whithout initial deposit should have gone through")
 }
 
 func (suite *AnteTestSuite) TestMinInitialDepositRatioWithSufficientDeposit() {
@@ -102,6 +118,22 @@ func (suite *AnteTestSuite) TestMinInitialDepositRatioWithSufficientDeposit() {
 	// antehandler should not error
 	_, err = antehandler(suite.ctx, tx, false)
 	suite.Require().NoError(err, "error: Proposal with sufficient initial deposit should have gone through")
+
+	// create v1 proposal
+	msgv1, _ := govv1.NewMsgSubmitProposal([]sdk.Msg{}, depositCoins1, addr1.String(), "metadata")
+	feeAmountv1 := testdata.NewTestFeeAmount()
+	gasLimitv1 := testdata.NewTestGasLimit()
+	suite.Require().NoError(suite.txBuilder.SetMsgs(msgv1))
+	suite.txBuilder.SetFeeAmount(feeAmountv1)
+	suite.txBuilder.SetGasLimit(gasLimitv1)
+	privs, accNums, accSeqs = []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	txv1, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
+	suite.Require().NoError(err)
+
+	// ante handler should not error for v1 proposal
+	_, err = antehandler(suite.ctx, txv1, false)
+	suite.Require().NoError(err, "error: v1 proposal with sufficient initial deposit should have gone through")
+
 }
 
 func (suite *AnteTestSuite) TestMinInitialDepositRatioWithInsufficientDeposit() {
@@ -144,4 +176,20 @@ func (suite *AnteTestSuite) TestMinInitialDepositRatioWithInsufficientDeposit() 
 	// antehandler should not error
 	_, err = antehandler(suite.ctx, tx, false)
 	suite.Require().Error(err, "error: Proposal with insufficient initial deposit should have failed")
+
+	// create v1 proposal
+	msgv1, _ := govv1.NewMsgSubmitProposal([]sdk.Msg{}, depositCoins1, addr1.String(), "metadata")
+	feeAmountv1 := testdata.NewTestFeeAmount()
+	gasLimitv1 := testdata.NewTestGasLimit()
+	suite.Require().NoError(suite.txBuilder.SetMsgs(msgv1))
+	suite.txBuilder.SetFeeAmount(feeAmountv1)
+	suite.txBuilder.SetGasLimit(gasLimitv1)
+	privs, accNums, accSeqs = []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	txv1, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
+	suite.Require().NoError(err)
+
+	// ante handler should not error for v1 proposal
+	_, err = antehandler(suite.ctx, txv1, false)
+	suite.Require().Error(err, "error: v1 proposal with insufficient initial deposit should have failed")
+
 }


### PR DESCRIPTION
## Summary of changes

This fixes a gap in the min initial deposit check in the ante handler. While the current ante handler checks `v1beta1.MsgSubmitProposal` proposals correctly it just ignored `v1.MsgSubmitProposal` to date.

- add the fix
- add tests to check `v1` proposals as well