### PR TITLE
fix: take dyncomm ante into account for `MsgRecvPackage`

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -216,6 +216,7 @@ func NewTerraApp(
 			TXCounterStoreKey:  app.GetKey(wasm.StoreKey),
 			DyncommKeeper:      app.DyncommKeeper,
 			StakingKeeper:      app.StakingKeeper,
+			Cdc:                app.appCodec,
 		},
 	)
 	if err != nil {

--- a/custom/auth/ante/ante.go
+++ b/custom/auth/ante/ante.go
@@ -3,6 +3,7 @@ package ante
 import (
 	dyncommante "github.com/classic-terra/core/v2/x/dyncomm/ante"
 	dyncommkeeper "github.com/classic-terra/core/v2/x/dyncomm/keeper"
+	"github.com/cosmos/cosmos-sdk/codec"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	ibcante "github.com/cosmos/ibc-go/v6/modules/core/ante"
 	ibckeeper "github.com/cosmos/ibc-go/v6/modules/core/keeper"
@@ -36,6 +37,7 @@ type HandlerOptions struct {
 	TXCounterStoreKey      storetypes.StoreKey
 	DyncommKeeper          dyncommkeeper.Keeper
 	StakingKeeper          stakingkeeper.Keeper
+	Cdc                    codec.BinaryCodec
 }
 
 // NewAnteHandler returns an AnteHandler that checks and increments sequence
@@ -84,7 +86,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		NewMinInitialDepositDecorator(options.GovKeeper, options.TreasuryKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
 		NewFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TreasuryKeeper),
-		dyncommante.NewDyncommDecorator(options.DyncommKeeper, options.StakingKeeper),
+		dyncommante.NewDyncommDecorator(options.Cdc, options.DyncommKeeper, options.StakingKeeper),
 
 		// Do not add any other decorators below this point unless explicitly explain.
 		ante.NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators

--- a/x/dyncomm/ante/ante.go
+++ b/x/dyncomm/ante/ante.go
@@ -6,6 +6,7 @@ import (
 	dyncommkeeper "github.com/classic-terra/core/v2/x/dyncomm/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authz "github.com/cosmos/cosmos-sdk/x/authz"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
@@ -41,9 +42,14 @@ func (dd DyncommDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool,
 func (dd DyncommDecorator) FilterMsgsAndProcessMsgs(ctx sdk.Context, msgs ...sdk.Msg) (err error) {
 	for _, msg := range msgs {
 
-		switch msg.(type) {
+		switch msg := msg.(type) {
 		case *stakingtypes.MsgEditValidator:
 			err = dd.ProcessEditValidator(ctx, msg)
+		case *authz.MsgExec:
+			messages, msgerr := msg.GetMessages()
+			if msgerr == nil {
+				err = dd.FilterMsgsAndProcessMsgs(ctx, messages...)
+			}
 		default:
 			continue
 		}


### PR DESCRIPTION
## Summary of changes

Let's be really pedantic.

ICA host capabilities are currently disabled on Terra Classic (ICA host parameter `enabled` is set to `false`). But if a param change governance prop passes that opens Terra Classic as ICA host chain, then the `MsgEditValidator` could be triggered via ICA - meaning `MsgEditValidator` comes wrapped inside a `MsgRecvPackage`.

Unit tests included.

Phew.