### PR TITLE
fix: take ICA into account for dyncomm ante

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -216,6 +216,7 @@ func NewTerraApp(
 			TXCounterStoreKey:  app.GetKey(wasm.StoreKey),
 			DyncommKeeper:      app.DyncommKeeper,
 			StakingKeeper:      app.StakingKeeper,
+			Cdc:                app.appCodec,
 		},
 	)
 	if err != nil {

--- a/custom/auth/ante/ante.go
+++ b/custom/auth/ante/ante.go
@@ -3,6 +3,7 @@ package ante
 import (
 	dyncommante "github.com/classic-terra/core/v2/x/dyncomm/ante"
 	dyncommkeeper "github.com/classic-terra/core/v2/x/dyncomm/keeper"
+	"github.com/cosmos/cosmos-sdk/codec"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	ibcante "github.com/cosmos/ibc-go/v6/modules/core/ante"
 	ibckeeper "github.com/cosmos/ibc-go/v6/modules/core/keeper"
@@ -36,6 +37,7 @@ type HandlerOptions struct {
 	TXCounterStoreKey      storetypes.StoreKey
 	DyncommKeeper          dyncommkeeper.Keeper
 	StakingKeeper          stakingkeeper.Keeper
+	Cdc                    codec.BinaryCodec
 }
 
 // NewAnteHandler returns an AnteHandler that checks and increments sequence
@@ -84,7 +86,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		NewMinInitialDepositDecorator(options.GovKeeper, options.TreasuryKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
 		NewFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TreasuryKeeper),
-		dyncommante.NewDyncommDecorator(options.DyncommKeeper, options.StakingKeeper),
+		dyncommante.NewDyncommDecorator(options.Cdc, options.DyncommKeeper, options.StakingKeeper),
 
 		// Do not add any other decorators below this point unless explicitly explain.
 		ante.NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators

--- a/x/dyncomm/ante/ante_test.go
+++ b/x/dyncomm/ante/ante_test.go
@@ -274,23 +274,20 @@ func (suite *AnteTestSuite) TestAnte_EnsureDynCommissionIsMinCommICA() {
 
 	dyncomm := suite.App.DyncommKeeper.CalculateDynCommission(suite.Ctx, val1)
 	invalidtarget := dyncomm.Mul(sdk.NewDecWithPrec(9, 1))
-	//validtarget := dyncomm.Mul(sdk.NewDecWithPrec(11, 1))
+	validtarget := dyncomm.Mul(sdk.NewDecWithPrec(11, 1))
 
-	// invalid tx fails
+	// prepare invalid tx -> expect it fails
 	editmsg := stakingtypes.NewMsgEditValidator(
 		val1.GetOperator(),
 		val1.Description, &invalidtarget, &val1.MinSelfDelegation,
 	)
-
 	data, err := icatypes.SerializeCosmosTx(suite.App.AppCodec(), []proto.Message{editmsg})
 	suite.Require().NoError(err)
-
 	icaPacketData := icatypes.InterchainAccountPacketData{
 		Type: icatypes.EXECUTE_TX,
 		Data: data,
 	}
 	packetData := icaPacketData.GetBytes()
-	//packetData, err := icatypes.ModuleCdc.MarshalJSON(&icaPacketData)
 	packet := channeltypes.NewPacket(
 		packetData, 1, "source-port", "source-channel",
 		"dest-port", "dest-channel",
@@ -307,19 +304,33 @@ func (suite *AnteTestSuite) TestAnte_EnsureDynCommissionIsMinCommICA() {
 	_, err = antehandler(suite.Ctx, tx, false)
 	suite.Require().Error(err)
 
-	// valid tx passes
-	/*editmsg = stakingtypes.NewMsgEditValidator(
+	// prepare valid tx -> expect it passes
+	editmsg = stakingtypes.NewMsgEditValidator(
 		val1.GetOperator(),
 		val1.Description, &validtarget, &val1.MinSelfDelegation,
 	)
-	execmsg = authz.NewMsgExec(acc2, []sdk.Msg{editmsg})
+	data, err = icatypes.SerializeCosmosTx(suite.App.AppCodec(), []proto.Message{editmsg})
+	suite.Require().NoError(err)
+	icaPacketData = icatypes.InterchainAccountPacketData{
+		Type: icatypes.EXECUTE_TX,
+		Data: data,
+	}
+	packetData = icaPacketData.GetBytes()
+	packet = channeltypes.NewPacket(
+		packetData, 1, "source-port", "source-channel",
+		"dest-port", "dest-channel",
+		clienttypes.NewHeight(1, 1), 0,
+	)
+	recvmsg = channeltypes.NewMsgRecvPacket(
+		packet, []byte{}, clienttypes.NewHeight(1, 1), "signer",
+	)
 
 	err = suite.txBuilder.SetMsgs(editmsg)
 	suite.Require().NoError(err)
 	tx, err = suite.CreateTestTx([]cryptotypes.PrivKey{priv2}, []uint64{0}, []uint64{0}, suite.Ctx.ChainID())
 	suite.Require().NoError(err)
 	_, err = antehandler(suite.Ctx, tx, false)
-	suite.Require().NoError(err)*/
+	suite.Require().NoError(err)
 }
 
 // go test -v -run ^TestAnteTestSuite/TestAnte_EditValidatorAccountSequence$ github.com/classic-terra/core/v2/x/dyncomm/ante

--- a/x/dyncomm/ante/ante_test.go
+++ b/x/dyncomm/ante/ante_test.go
@@ -325,7 +325,7 @@ func (suite *AnteTestSuite) TestAnte_EnsureDynCommissionIsMinCommICA() {
 		packet, []byte{}, clienttypes.NewHeight(1, 1), "signer",
 	)
 
-	err = suite.txBuilder.SetMsgs(editmsg)
+	err = suite.txBuilder.SetMsgs(recvmsg)
 	suite.Require().NoError(err)
 	tx, err = suite.CreateTestTx([]cryptotypes.PrivKey{priv2}, []uint64{0}, []uint64{0}, suite.Ctx.ChainID())
 	suite.Require().NoError(err)


### PR DESCRIPTION
Referencing closed PR #449 

---

Let's be really pedantic.

ICA host capabilities are currently disabled on Terra Classic (ICA host parameter enabled is set to false). But if a param change governance prop passes that opens Terra Classic as ICA host chain, then the MsgEditValidator could be triggered via ICA - meaning MsgEditValidator comes wrapped inside a MsgRecvPackage.

Unit tests included.

Phew.
