### PR TITLE
Improve simulation handling for tax transactions

### DIFF
--- a/custom/auth/ante/fee.go
+++ b/custom/auth/ante/fee.go
@@ -99,7 +99,7 @@ func (fd FeeDecorator) checkDeductFee(ctx sdk.Context, feeTx sdk.FeeTx, taxes sd
 		return sdkerrors.ErrUnknownAddress.Wrapf("fee payer address: %s does not exist", deductFeesFrom)
 	}
 
-	var feesOrTax = fee
+	feesOrTax := fee
 
 	// deduct the fees
 	if fee.IsZero() && simulate {


### PR DESCRIPTION
## Summary of changes

Currently simulations do not take into account any burn tax split operations.
This has been like this since that feature was introduced long ago. We found out that this has a significant influence on estimated gas, so makes estimations less reliable.
This fix aims to make a non-state-breaking change that only endpoints need to install which are queried for simulation (gas estimation).

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
