### PR TITLE
feat: wasmd v0.46.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,21 +336,21 @@ localnet-start: localnet-stop build-linux
 		-v /etc/shadow:/etc/shadow:ro \
 		classic-terra/terrad-env testnet --chain-id ${TESTNET_CHAINID} --v ${TESTNET_NVAL} -o . --starting-ip-address 192.168.10.2 --keyring-backend=test; \
 	fi
-	docker-compose up -d
+	docker compose up -d
 
 localnet-start-upgrade: localnet-upgrade-stop build-linux
 	$(MAKE) -C contrib/updates build-cosmovisor-linux BUILDDIR=$(BUILDDIR)
 	$(if $(shell $(DOCKER) inspect -f '{{ .Id }}' classic-terra/terrad-upgrade-env 2>/dev/null),$(info found image classic-terra/terrad-upgrade-env),$(MAKE) -C contrib/localnet terrad-upgrade-env)
 	bash contrib/updates/prepare_cosmovisor.sh $(BUILDDIR) ${TESTNET_NVAL} ${TESTNET_CHAINID}
-	docker-compose -f ./contrib/updates/docker-compose.yml up -d
+	docker compose -f ./contrib/updates/docker-compose.yml up -d
 
 localnet-upgrade-stop:
-	docker-compose -f ./contrib/updates/docker-compose.yml down
+	docker compose -f ./contrib/updates/docker-compose.yml down
 	rm -rf build/node*
 	rm -rf build/gentxs
 
 localnet-stop:
-	docker-compose down
+	docker compose down
 	rm -rf build/node*
 	rm -rf build/gentxs
 
@@ -363,10 +363,10 @@ localnet-stop:
 build-operator-img-all: build-operator-img-core build-operator-img-node
 
 build-operator-img-core:
-	docker-compose -f contrib/terra-operator/docker-compose.build.yml build core --no-cache
+	docker compose -f contrib/terra-operator/docker-compose.build.yml build core --no-cache
 
 build-operator-img-node:
 	@if ! docker image inspect public.ecr.aws/classic-terra/core:${NODE_VERSION} &>/dev/null ; then make build-operator-img-core ; fi
-	docker-compose -f contrib/terra-operator/docker-compose.build.yml build node --no-cache
+	docker compose -f contrib/terra-operator/docker-compose.build.yml build node --no-cache
 
 .PHONY: build-operator-img-all build-operator-img-core build-operator-img-node

--- a/README.md
+++ b/README.md
@@ -272,12 +272,12 @@ journalctl -t terrad -r
 journalctl -t terrad -f
 ```
 
-## Using `docker-compose`
+## Using `docker compose`
 
 1. Install Docker
 
 	- [Docker Install documentation](https://docs.docker.com/install/)
-	- [Docker-Compose Install documentation](https://docs.docker.com/compose/install/)
+	- [Docker Compose Install documentation](https://docs.docker.com/compose/install/)
 
 2. Create a new folder on your local machine and copy docker-compose\docker-compose.yml
 
@@ -286,19 +286,19 @@ journalctl -t terrad -f
 4. Bring up your stack by running
 
 	```bash
-	docker-compose up -d
+	docker compose up -d
 	```
 
 5. Add your wallet
     ```bash
-	docker-compose exec node sh /keys-add.sh
+	docker compose exec node sh /keys-add.sh
 	```
 
 6. Copy your terra wallet address and go to the terra faucet here -> http://45.79.139.229:3000/ Put your address in and give yourself luna coins.
 
 7. Start the validator
 	```bash
-	docker-compose exec node sh /create-validator.sh
+	docker compose exec node sh /create-validator.sh
 	```
 
 ### Cheat Sheet:
@@ -306,33 +306,33 @@ journalctl -t terrad -f
 #### Start
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 #### Stop
 
 ```bash
-docker-compose down
+docker compose down
 ```
 
 #### View Logs
 
 ```bash
-docker-compose logs -f
+docker compose logs -f
 ```
 
 #### Run Terrad Commands Example
 
 ```bash
-docker-compose exec node terrad status
+docker compose exec node terrad status
 ```
 
 #### Upgrade
 
 ```bash
-docker-compose down
-docker-compose pull
-docker-compose up -d
+docker compose down
+docker compose pull
+docker compose up -d
 ```
 
 #### Build from source

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -512,7 +512,7 @@ func initParamsKeeper(
 	paramsKeeper.Subspace(markettypes.ModuleName)
 	paramsKeeper.Subspace(oracletypes.ModuleName)
 	paramsKeeper.Subspace(treasurytypes.ModuleName)
-	paramsKeeper.Subspace(wasmtypes.ModuleName).WithKeyTable(wasmtypes.ParamKeyTable())
+	paramsKeeper.Subspace(wasmtypes.ModuleName)
 	paramsKeeper.Subspace(dyncommtypes.ModuleName)
 
 	return paramsKeeper

--- a/app/upgrades/v8/upgrades.go
+++ b/app/upgrades/v8/upgrades.go
@@ -1,6 +1,7 @@
 package v8
 
 import (
+	wasmmigration "github.com/CosmWasm/wasmd/x/wasm/migrations/v2"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/classic-terra/core/v3/app/keepers"
 	"github.com/classic-terra/core/v3/app/upgrades"
@@ -49,7 +50,7 @@ func CreateV8UpgradeHandler(
 			case govtypes.ModuleName:
 				keyTable = govv1.ParamKeyTable()
 			case wasmtypes.ModuleName:
-				keyTable = wasmtypes.ParamKeyTable()
+				keyTable = wasmmigration.ParamKeyTable()
 			case crisistypes.ModuleName:
 				keyTable = crisistypes.ParamKeyTable()
 			}

--- a/contrib/updates/Dockerfile.cosmovisor
+++ b/contrib/updates/Dockerfile.cosmovisor
@@ -3,6 +3,6 @@ FROM golang:1.20-alpine3.18
 RUN set -eux; apk add --no-cache ca-certificates build-base;
 
 # make cosmovisor statically linked
-RUN go install -ldflags '-w -s -linkmode=external -extldflags "-Wl,-z,muldefs -static"' -trimpath cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
+RUN go install -ldflags '-w -s -linkmode=external -extldflags "-Wl,-z,muldefs -static"' -trimpath cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
 
 ENTRYPOINT [ "/bin/sh" ]

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	cosmossdk.io/errors v1.0.1
 	cosmossdk.io/math v1.3.0
 	cosmossdk.io/simapp v0.0.0-20230602123434-616841b9704d
-	github.com/CosmWasm/wasmd v0.45.0
-	github.com/CosmWasm/wasmvm v1.5.2
+	github.com/CosmWasm/wasmd v0.46.0
+	github.com/CosmWasm/wasmvm v1.5.4
 	github.com/cometbft/cometbft v0.37.4
 	github.com/cometbft/cometbft-db v0.8.0
 	github.com/cosmos/cosmos-sdk v0.47.10
@@ -225,7 +225,7 @@ replace (
 )
 
 replace (
-	github.com/CosmWasm/wasmd => github.com/classic-terra/wasmd v0.45.0-terra.5
+	github.com/CosmWasm/wasmd => github.com/classic-terra/wasmd v0.46.0-classic.1
 	// use cometbft
 	github.com/cometbft/cometbft => github.com/classic-terra/cometbft v0.37.4-terra1
 	github.com/cometbft/cometbft-db => github.com/cometbft/cometbft-db v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChainSafe/go-schnorrkel v1.0.0 h1:3aDA67lAykLaG1y3AOjs88dMxC88PgUuHRrLeDnvGIM=
 github.com/ChainSafe/go-schnorrkel v1.0.0/go.mod h1:dpzHYVxLZcp8pjlV+O+UR8K0Hp/z7vcchBSbMBEhCw4=
-github.com/CosmWasm/wasmvm v1.5.2 h1:+pKB1Mz9GZVt1vadxB+EDdD1FOz3dMNjIKq/58/lrag=
-github.com/CosmWasm/wasmvm v1.5.2/go.mod h1:Q0bSEtlktzh7W2hhEaifrFp1Erx11ckQZmjq8FLCyys=
+github.com/CosmWasm/wasmvm v1.5.4 h1:Opqy65ubJ8bMsT08dn85VjRdsLJVPIAgIXif92qOMGc=
+github.com/CosmWasm/wasmvm v1.5.4/go.mod h1:Q0bSEtlktzh7W2hhEaifrFp1Erx11ckQZmjq8FLCyys=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
@@ -356,8 +356,8 @@ github.com/classic-terra/goleveldb v0.0.0-20230914223247-2b28f6655121 h1:fjpWDB0
 github.com/classic-terra/goleveldb v0.0.0-20230914223247-2b28f6655121/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/classic-terra/ibc-go/v7 v7.4.0-terra h1:hawaq62XKlxyc8xLyIcc6IujDDEbqDBU+2U15SF+hj8=
 github.com/classic-terra/ibc-go/v7 v7.4.0-terra/go.mod h1:s0lxNkjVIqsb8AVltL0qhzxeLgOKvWZrknPuvgjlEQ8=
-github.com/classic-terra/wasmd v0.45.0-terra.5 h1:0fuc4lS1Z0Egci6hwK4DZqOwF2l9fGsZuPTZ1akObFY=
-github.com/classic-terra/wasmd v0.45.0-terra.5/go.mod h1:r/AxjzSLyrQbrANEsV/d+qf/vmCDFiAoVwWenGs23ZY=
+github.com/classic-terra/wasmd v0.46.0-classic.1 h1:+EHlqAD8r8Q2jOpjJoKGOTQFW9iD5cV8fKc0XxkZ5O0=
+github.com/classic-terra/wasmd v0.46.0-classic.1/go.mod h1:dF31qSPGrHgGPreCCIbAtw/YnJT0Gi997sAA5ZllPSI=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.14.0/go.mod h1:EnwdgGMaFOruiPZRFSgn+TsQ3hQ7C/YWzIGLeu5c304=


### PR DESCRIPTION
This PR does:
- Update wasmvm version to v1.5.4 which has fixes for CWA-2024-003 and CWA-2024-004.
- Use wasmd version v0.46.0 to fixes CWA-2024-005

References:
https://github.com/CosmWasm/advisories/blob/main/CWAs/CWA-2024-003.md
https://github.com/CosmWasm/advisories/blob/main/CWAs/CWA-2024-004.md
https://github.com/CosmWasm/advisories/blob/main/CWAs/CWA-2024-005.md