### PR TITLE
handle excessive fee deduction during simulation

### DIFF
--- a/custom/auth/ante/expected_keeper.go
+++ b/custom/auth/ante/expected_keeper.go
@@ -30,6 +30,8 @@ type BankKeeper interface {
 	SendCoins(ctx sdk.Context, from, to sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	SendCoinsFromModuleToModule(ctx sdk.Context, senderModule string, recipientModule string, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+	MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
 }
 
 type DistrKeeper interface {


### PR DESCRIPTION
## Summary of changes

As we need to deduct the fees and tax to be able to handle the gas estimations correctly, there is a deviation from the normal upstream behavior where only sent fees are deducted. This PR addresses that.  
It is an endpoint change only (simulation mode only) and not relevant for consensus.