### PR TITLE
feat: wasmvm interface versions 1_2, 1_3

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -386,7 +386,7 @@ func NewAppKeepers(
 	if err != nil {
 		panic("error while reading wasm config: " + err.Error())
 	}
-	supportedFeatures := "iterator,staking,stargate,terra,cosmwasm_1_1"
+	supportedFeatures := "iterator,staking,stargate,terra,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3"
 
 	wasmMsgHandler := customwasmkeeper.NewMessageHandler(
 		bApp.MsgServiceRouter(),


### PR DESCRIPTION
This is a last second change request for v3.4.1

This enabled cosmwasm interface versions `1_2` and `1_3`