### PR TITLE
Fix: Do not use alpine 3.19+ for building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,22 @@
 ARG source=./
 ARG GO_VERSION="1.22.12"
 ARG BUILDPLATFORM=linux/amd64
-ARG BASE_IMAGE="golang:${GO_VERSION}-alpine3.20"
-FROM --platform=${BUILDPLATFORM} ${BASE_IMAGE} AS base
+
+# Get Go installation from the official image
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS go-source
+
+# Use Alpine 3.18 as base for muslc compatibility
+FROM --platform=${BUILDPLATFORM} alpine:3.18 AS base
+
+# Copy Go from the official image
+COPY --from=go-source /usr/local/go /usr/local/go
+# Setup Go environment properly
+ENV GOPATH="/go" \
+    PATH="/usr/local/go/bin:/go/bin:${PATH}"
+# Create necessary directories
+RUN mkdir -p "$GOPATH/bin" "$GOPATH/src" && \
+    # Verify Go installation
+    go version
 
 ###############################################################################
 # Builder


### PR DESCRIPTION
This pull request includes significant changes to the `Dockerfile` to improve the Go environment setup and ensure compatibility with muslc by using Alpine 3.18 as the base image. The most important changes are listed below:

### Dockerfile improvements:

* Changed the base image from `golang:${GO_VERSION}-alpine3.20` to `alpine:3.18` for muslc compatibility.
* Added a new stage to get the Go installation from the official Go image (`golang:${GO_VERSION}`).
* Copied the Go installation from the official Go image to the new Alpine base image.
* Set up the Go environment by configuring `GOPATH` and updating the `PATH`.
* Created necessary directories and verified the Go installation

See https://github.com/CosmWasm/wasmvm/issues/523

Crash report:
```
SIGABRT: abort
PC=0x2f405f5 m=16 sigcode=18446744073709551610
signal arrived during cgo execution

goroutine 13301 gp=0xc0014a4a80 m=16 mp=0xc001288008 [syscall, locked to thread]:
runtime.cgocall(0x249a8d0, 0xc066f115f8)
  runtime/cgocall.go:157 +0x4b fp=0xc066f115d0 sp=0xc066f11598 pc=0x457d8b
github.com/CosmWasm/wasmvm/internal/api._C2func_query(0x405d6170280, {0x0, 0xc0664ec100, 0x20}, {0x0, 0xc049ab6a80, 0xbf}, {0x0, 0xc061323e00, 0x11}, ...)
  _cgo_gotypes.go:602 +0x71 fp=0xc066f115f8 sp=0xc066f115d0 pc=0x7fd971
github.com/CosmWasm/wasmvm/internal/api.Query.func1({0x1?}, {0x10?, 0xc0664ec100?, 0x3?}, {0x60?, 0xc049ab6a80?, 0xc177347a88?}, {0x0, 0xc061323e00, 0x11}, ...)
```

From the linked issue:
![grafik](https://github.com/user-attachments/assets/89fd5203-82fe-44b8-b3c6-78814e168d39)

May closes #555 