### PR TITLE
Fix error in compute_tax endpoint

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -444,7 +444,7 @@ func (app *TerraApp) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.APIC
 // RegisterTxService implements the Application.RegisterTxService method.
 func (app *TerraApp) RegisterTxService(clientCtx client.Context) {
 	authtx.RegisterTxService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.BaseApp.Simulate, app.interfaceRegistry)
-	customauthtx.RegisterTxService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.TreasuryKeeper, app.TaxKeeper)
+	customauthtx.RegisterTxService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.TreasuryKeeper, app.TaxExemptionKeeper, app.TaxKeeper)
 }
 
 // RegisterTendermintService implements the Application.RegisterTendermintService method.

--- a/custom/auth/tx/service.go
+++ b/custom/auth/tx/service.go
@@ -27,11 +27,17 @@ type txServer struct {
 }
 
 // NewTxServer creates a new Tx service server.
-func NewTxServer(clientCtx client.Context, treasuryKeeper customante.TreasuryKeeper, taxKeeper customante.TaxKeeper) ServiceServer {
+func NewTxServer(
+	clientCtx client.Context,
+	treasuryKeeper customante.TreasuryKeeper,
+	taxExemptionKeeper taxexemptionkeeper.Keeper,
+	taxKeeper customante.TaxKeeper,
+) ServiceServer {
 	return txServer{
-		clientCtx:      clientCtx,
-		treasuryKeeper: treasuryKeeper,
-		taxKeeper:      taxKeeper,
+		clientCtx:          clientCtx,
+		treasuryKeeper:     treasuryKeeper,
+		taxexemptionKeeper: taxExemptionKeeper,
+		taxKeeper:          taxKeeper,
 	}
 }
 
@@ -67,11 +73,12 @@ func RegisterTxService(
 	qrt gogogrpc.Server,
 	clientCtx client.Context,
 	treasuryKeeper customante.TreasuryKeeper,
+	taxExemptionKeeper taxexemptionkeeper.Keeper,
 	taxKeeper customante.TaxKeeper,
 ) {
 	RegisterServiceServer(
 		qrt,
-		NewTxServer(clientCtx, treasuryKeeper, taxKeeper),
+		NewTxServer(clientCtx, treasuryKeeper, taxExemptionKeeper, taxKeeper),
 	)
 }
 


### PR DESCRIPTION
## Summary of changes

This patch fixes an issue in computing the tax via the compute_tax LCD endpoint.

```
After v3.5.0 upgrade, the REST API /terra/tx/v1beta1/compute_tax raises an error:
code: 13
message: kv store with key <nil> has not been registered in stores
```