### PR TITLE
fix(cli): show zero-value fields in slashing signing-info output

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -46,6 +46,7 @@ import (
 	customante "github.com/classic-terra/core/v4/custom/auth/ante"
 	custompost "github.com/classic-terra/core/v4/custom/auth/post"
 	customauthtx "github.com/classic-terra/core/v4/custom/auth/tx"
+	customslashing "github.com/classic-terra/core/v4/custom/slashing"
 	customserver "github.com/classic-terra/core/v4/server"
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmjson "github.com/cometbft/cometbft/libs/json"
@@ -465,9 +466,11 @@ func (app *TerraApp) SimulationManager() *module.SimulationManager {
 // (e.g., with codecs) to construct tx/query commands safely.
 func (app *TerraApp) BasicModuleManager() module.BasicManager {
 	// Use the SDK helper which extracts module basics (with initialized codecs)
-	// from the module manager, ensuring CLI commands from upstream modules are
-	// wired correctly.
-	return module.NewBasicManagerFromManager(app.mm, nil)
+	// from the module manager, while overriding select modules with our custom
+	// CLI basics where we intentionally diverge from upstream behavior.
+	return module.NewBasicManagerFromManager(app.mm, map[string]module.AppModuleBasic{
+		"slashing": customslashing.AppModuleBasic{},
+	})
 }
 
 // RegisterAPIRoutes registers all application module routes with the provided

--- a/custom/slashing/client/cli/query.go
+++ b/custom/slashing/client/cli/query.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/spf13/cobra"
+)
+
+// GetQueryCmd returns the slashing query commands.
+func GetQueryCmd() *cobra.Command {
+	slashingQueryCmd := &cobra.Command{
+		Use:                        slashingtypes.ModuleName,
+		Short:                      fmt.Sprintf("Querying commands for the %s module", slashingtypes.ModuleName),
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	slashingQueryCmd.AddCommand(
+		GetCmdQueryParams(),
+		GetCmdQuerySigningInfo(),
+		GetCmdQuerySigningInfos(),
+	)
+
+	return slashingQueryCmd
+}
+
+// GetCmdQueryParams returns the current slashing parameters.
+func GetCmdQueryParams() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "params",
+		Short: "Query the current slashing parameters",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := slashingtypes.NewQueryClient(clientCtx)
+			res, err := queryClient.Params(cmd.Context(), &slashingtypes.QueryParamsRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetCmdQuerySigningInfo queries a validator's signing information.
+func GetCmdQuerySigningInfo() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "signing-info [validator-conspub/address]",
+		Short: "Query a validator's signing information",
+		Long:  "Query a validator's signing information, with a pubkey ('<appd> comet show-validator') or a validator consensus address",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			consAddr, err := normalizeConsAddressArg(clientCtx, args[0])
+			if err != nil {
+				return err
+			}
+
+			queryClient := slashingtypes.NewQueryClient(clientCtx)
+			res, err := queryClient.SigningInfo(
+				cmd.Context(),
+				&slashingtypes.QuerySigningInfoRequest{ConsAddress: consAddr},
+			)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetCmdQuerySigningInfos queries signing information for all validators.
+func GetCmdQuerySigningInfos() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "signing-infos",
+		Short: "Query signing information of all validators",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			queryClient := slashingtypes.NewQueryClient(clientCtx)
+			res, err := queryClient.SigningInfos(
+				cmd.Context(),
+				&slashingtypes.QuerySigningInfosRequest{Pagination: pageReq},
+			)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "signing infos")
+
+	return cmd
+}
+
+func normalizeConsAddressArg(clientCtx client.Context, arg string) (string, error) {
+	arg = strings.TrimSpace(arg)
+
+	if _, err := sdk.ConsAddressFromBech32(arg); err == nil {
+		return arg, nil
+	}
+
+	var pubKey cryptotypes.PubKey
+	if err := clientCtx.Codec.UnmarshalInterfaceJSON([]byte(arg), &pubKey); err == nil && pubKey != nil {
+		return sdk.GetConsAddress(pubKey).String(), nil
+	}
+
+	return "", fmt.Errorf("invalid consensus address or pubkey JSON: %q", arg)
+}

--- a/custom/slashing/client/cli/query_test.go
+++ b/custom/slashing/client/cli/query_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/cosmos/cosmos-sdk/std"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeConsAddressArg_AcceptsConsensusAddress(t *testing.T) {
+	clientCtx := makeTestClientContext()
+	pubKey := ed25519.GenPrivKey().PubKey()
+	consAddr := sdk.GetConsAddress(pubKey).String()
+
+	got, err := normalizeConsAddressArg(clientCtx, consAddr)
+	require.NoError(t, err)
+	require.Equal(t, consAddr, got)
+}
+
+func TestNormalizeConsAddressArg_AcceptsConsensusPubKeyJSON(t *testing.T) {
+	clientCtx := makeTestClientContext()
+	pubKey := ed25519.GenPrivKey().PubKey()
+
+	bz, err := clientCtx.Codec.MarshalInterfaceJSON(pubKey)
+	require.NoError(t, err)
+
+	got, err := normalizeConsAddressArg(clientCtx, string(bz))
+	require.NoError(t, err)
+	require.Equal(t, sdk.GetConsAddress(pubKey).String(), got)
+}
+
+func TestPrintProtoIncludesZeroValueSigningFields(t *testing.T) {
+	clientCtx := makeTestClientContext()
+	var out bytes.Buffer
+
+	clientCtx = clientCtx.WithOutput(&out).WithOutputFormat("json")
+
+	res := &slashingtypes.QuerySigningInfoResponse{
+		ValSigningInfo: slashingtypes.ValidatorSigningInfo{
+			Address:     sdk.GetConsAddress(ed25519.GenPrivKey().PubKey()).String(),
+			StartHeight: 27267533,
+			IndexOffset: 2826250,
+		},
+	}
+
+	err := clientCtx.PrintProto(res)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), `"tombstoned":false`)
+	require.Contains(t, out.String(), `"missed_blocks_counter":"0"`)
+}
+
+func makeTestClientContext() client.Context {
+	ir := codectypes.NewInterfaceRegistry()
+	std.RegisterInterfaces(ir)
+
+	return client.Context{}.WithCodec(codec.NewProtoCodec(ir))
+}

--- a/custom/slashing/module.go
+++ b/custom/slashing/module.go
@@ -1,10 +1,12 @@
 package slashing
 
 import (
+	"github.com/classic-terra/core/v4/custom/slashing/client/cli"
 	customtypes "github.com/classic-terra/core/v4/custom/slashing/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/slashing"
+	"github.com/spf13/cobra"
 )
 
 var _ module.AppModuleBasic = AppModuleBasic{}
@@ -17,4 +19,10 @@ type AppModuleBasic struct {
 // RegisterLegacyAminoCodec registers the slashing module's types for the given codec.
 func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	customtypes.RegisterLegacyAminoCodec(cdc)
+}
+
+// GetQueryCmd returns a manual query command so slashing queries use PrintProto
+// output instead of AutoCLI aminojson output, which omits zero-value fields.
+func (AppModuleBasic) GetQueryCmd() *cobra.Command {
+	return cli.GetQueryCmd()
 }


### PR DESCRIPTION
## Summary of changes

<Describe summary of major changes here>

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
